### PR TITLE
use updated project id from access key api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "codex-sdk @ git+ssh://git@github.com/cleanlab/codex-python.git@65e466e57f61cacd16af61a3c506a9907380d9fe", # TODO: update this once we've published SDK
+  "codex-sdk @ git+ssh://git@github.com/cleanlab/codex-python.git@8121c341af5ecca80a946ae3ba7e0f74036ca8d9", # TODO: update this once we've published SDK
   "pydantic>=1.9.0, <3",
 ]
 

--- a/src/cleanlab_codex/internal/project.py
+++ b/src/cleanlab_codex/internal/project.py
@@ -36,7 +36,7 @@ def query_project(
     read_only: bool = False,
 ) -> tuple[Optional[str], Optional[Entry]]:
     if client.access_key is not None:
-        project_id = client.projects.access_keys.retrieve_project_id()
+        project_id = client.projects.access_keys.retrieve_project_id().project_id
     elif project_id is None:
         raise MissingProjectIdError
 


### PR DESCRIPTION
Fixes issue where previously, the SDK client was returning project ID wrapped in quotes. Updates this client library to use the updated API.