### PR TITLE
Update badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Cleanlab Codex [![Build Status](https://github.com/cleanlab/cleanlab-codex/workflows/CI/badge.svg)](https://github.com/cleanlab/cleanlab-codex/actions?query=workflow%3ACI) [![PyPI - Version](https://img.shields.io/pypi/v/cleanlab-codex.svg)](https://pypi.org/project/cleanlab-codex) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/cleanlab-codex.svg)](https://pypi.org/project/cleanlab-codex)
-
------
+# Cleanlab Codex [![Build Status](https://github.com/cleanlab/cleanlab-codex/actions/workflows/ci.yml/badge.svg)](https://github.com/cleanlab/cleanlab-codex/actions/workflows/ci.yml) [![PyPI - Version](https://img.shields.io/pypi/v/cleanlab-codex.svg)](https://pypi.org/project/cleanlab-codex) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/cleanlab-codex.svg)](https://pypi.org/project/cleanlab-codex)
 
 ## Table of Contents
 


### PR DESCRIPTION
The previous URL showed the status of the latest run of the action (e.g., on a pull request). The URL that we switch to in this patch displays the status of the latest run for the default branch [[1]]:

> By default, badges display the status of your default branch. If there are no workflow runs on your default branch, it will display the status of the most recent run across all branches.

[1]: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge