### PR TITLE
fix model validation in pydantic;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pydantic model validation error when querying Project and listing Organizations.
+
 ## [0.0.1a3] - 2025-02-06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "codex-sdk==0.1.0a9",
-  "pydantic>=1.9.0, <3",
+  "pydantic==2.10",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "codex-sdk==0.1.0a9",
-  "pydantic>=1.9.0, <3",
+  "pydantic>=2.0.0, <3",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "codex-sdk==0.1.0a9",
-  "pydantic==2.10",
+  "pydantic>=1.9.0, <3",
 ]
 
 [project.urls]

--- a/src/cleanlab_codex/internal/organization.py
+++ b/src/cleanlab_codex/internal/organization.py
@@ -9,4 +9,6 @@ from cleanlab_codex.types.organization import Organization
 
 
 def list_organizations(client: _Codex) -> list[Organization]:
-    return [Organization.model_validate(org) for org in client.users.myself.organizations.list().organizations]
+    return [
+        Organization.model_validate(org.model_dump()) for org in client.users.myself.organizations.list().organizations
+    ]

--- a/src/cleanlab_codex/internal/organization.py
+++ b/src/cleanlab_codex/internal/organization.py
@@ -9,4 +9,4 @@ from cleanlab_codex.types.organization import Organization
 
 
 def list_organizations(client: _Codex) -> list[Organization]:
-    return [Organization.model_validate(org) for org in client.users.myself.organizations.list().organizations]
+    return [Organization.model_validate(org.model_dump()) for org in client.users.myself.organizations.list().organizations]

--- a/src/cleanlab_codex/internal/organization.py
+++ b/src/cleanlab_codex/internal/organization.py
@@ -9,6 +9,4 @@ from cleanlab_codex.types.organization import Organization
 
 
 def list_organizations(client: _Codex) -> list[Organization]:
-    return [
-        Organization.model_validate(org.model_dump()) for org in client.users.myself.organizations.list().organizations
-    ]
+    return [Organization.model_validate(org) for org in client.users.myself.organizations.list().organizations]

--- a/src/cleanlab_codex/internal/organization.py
+++ b/src/cleanlab_codex/internal/organization.py
@@ -9,4 +9,6 @@ from cleanlab_codex.types.organization import Organization
 
 
 def list_organizations(client: _Codex) -> list[Organization]:
-    return [Organization.model_validate(org.model_dump()) for org in client.users.myself.organizations.list().organizations]
+    return [
+        Organization.model_validate(org.model_dump()) for org in client.users.myself.organizations.list().organizations
+    ]

--- a/src/cleanlab_codex/internal/project.py
+++ b/src/cleanlab_codex/internal/project.py
@@ -25,14 +25,16 @@ def query_project(
 ) -> tuple[Optional[str], Optional[Entry]]:
     maybe_entry = client.projects.entries.query(project_id, question=question)
     if maybe_entry is not None:
-        entry = Entry.model_validate(maybe_entry)
+        entry = Entry.model_validate(maybe_entry.model_dump())
         if entry.answer is not None:
             return entry.answer, entry
 
         return fallback_answer, entry
 
     if not read_only:
-        created_entry = Entry.model_validate(client.projects.entries.add_question(project_id, question=question))
+        created_entry = Entry.model_validate(
+            client.projects.entries.add_question(project_id, question=question).model_dump()
+        )
         return fallback_answer, created_entry
 
     return fallback_answer, None

--- a/src/cleanlab_codex/internal/project.py
+++ b/src/cleanlab_codex/internal/project.py
@@ -25,16 +25,14 @@ def query_project(
 ) -> tuple[Optional[str], Optional[Entry]]:
     maybe_entry = client.projects.entries.query(project_id, question=question)
     if maybe_entry is not None:
-        entry = Entry.model_validate(maybe_entry.model_dump())
+        entry = Entry.model_validate(maybe_entry)
         if entry.answer is not None:
             return entry.answer, entry
 
         return fallback_answer, entry
 
     if not read_only:
-        created_entry = Entry.model_validate(
-            client.projects.entries.add_question(project_id, question=question).model_dump()
-        )
+        created_entry = Entry.model_validate(client.projects.entries.add_question(project_id, question=question))
         return fallback_answer, created_entry
 
     return fallback_answer, None

--- a/src/cleanlab_codex/internal/project.py
+++ b/src/cleanlab_codex/internal/project.py
@@ -32,7 +32,9 @@ def query_project(
         return fallback_answer, entry
 
     if not read_only:
-        created_entry = Entry.model_validate(client.projects.entries.add_question(project_id, question=question).model_dump())
+        created_entry = Entry.model_validate(
+            client.projects.entries.add_question(project_id, question=question).model_dump()
+        )
         return fallback_answer, created_entry
 
     return fallback_answer, None

--- a/src/cleanlab_codex/internal/project.py
+++ b/src/cleanlab_codex/internal/project.py
@@ -25,14 +25,14 @@ def query_project(
 ) -> tuple[Optional[str], Optional[Entry]]:
     maybe_entry = client.projects.entries.query(project_id, question=question)
     if maybe_entry is not None:
-        entry = Entry.model_validate(maybe_entry)
+        entry = Entry.model_validate(maybe_entry.model_dump())
         if entry.answer is not None:
             return entry.answer, entry
 
         return fallback_answer, entry
 
     if not read_only:
-        created_entry = Entry.model_validate(client.projects.entries.add_question(project_id, question=question))
+        created_entry = Entry.model_validate(client.projects.entries.add_question(project_id, question=question).model_dump())
         return fallback_answer, created_entry
 
     return fallback_answer, None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,11 +8,11 @@ import pytest
 from codex import AuthenticationError
 from codex.types.project_return_schema import Config as ProjectReturnConfig
 from codex.types.project_return_schema import ProjectReturnSchema
+from codex.types.users.myself.user_organizations_schema import Organization as SDKOrganization
 from codex.types.users.myself.user_organizations_schema import UserOrganizationsSchema
 
 from cleanlab_codex.client import Client
 from cleanlab_codex.project import MissingProjectError
-from cleanlab_codex.types.organization import Organization
 from cleanlab_codex.types.project import ProjectConfig
 
 FAKE_PROJECT_ID = str(uuid.uuid4())
@@ -29,7 +29,7 @@ def test_client_uses_default_organization(mock_client_from_api_key: MagicMock) -
     default_org_id = "default-org-id"
     mock_client_from_api_key.users.myself.organizations.list.return_value = UserOrganizationsSchema(
         organizations=[
-            Organization(
+            SDKOrganization(
                 organization_id=default_org_id,
                 created_at=datetime.now(),
                 updated_at=datetime.now(),
@@ -98,7 +98,7 @@ def test_get_project_not_found(mock_client_from_api_key: MagicMock) -> None:
 def test_list_organizations(mock_client_from_api_key: MagicMock) -> None:
     mock_client_from_api_key.users.myself.organizations.list.return_value = UserOrganizationsSchema(
         organizations=[
-            Organization(
+            SDKOrganization(
                 organization_id=FAKE_ORGANIZATION_ID,
                 created_at=datetime.now(),
                 updated_at=datetime.now(),

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -156,7 +156,14 @@ def test_query_question_found_fallback_answer(mock_client_from_access_key: Magic
 
 def test_query_question_not_found_fallback_answer(mock_client_from_access_key: MagicMock) -> None:
     mock_client_from_access_key.projects.entries.query.return_value = None
-    mock_client_from_access_key.projects.entries.add_question.return_value = MagicMock(spec=Entry)
+    mock_entry = MagicMock(spec=Entry)
+    mock_entry.model_dump.return_value = {
+        "id": "fake-id",
+        "created_at": "2023-10-01T00:00:00Z",
+        "question": "What is the capital of France?",
+        "answer": None,
+    }
+    mock_client_from_access_key.projects.entries.add_question.return_value = mock_entry
 
     project = Project(mock_client_from_access_key, FAKE_PROJECT_ID)
     res = project.query("What is the capital of France?", fallback_answer="Paris")


### PR DESCRIPTION
Fix validation error in Pydantic: 

```

---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
Cell In[13], line 1
----> 1 codex_tool.query("WHat is this?")

File ~/anaconda3/envs/codex/lib/python3.10/site-packages/cleanlab_codex/codex_tool.py:107, in CodexTool.query(self, question)
     92 def query(
     93     self,
     94     question: Annotated[
   (...)
     97     ],
     98 ) -> Optional[str]:
     99     """Asks an all-knowing advisor this question in cases where it cannot be answered from the provided Context. If the answer is unavailable, this returns a fallback answer or None.
    100 
    101     Args:
   (...)
    105         The answer to the question if available. If no answer is available, this returns a fallback answer or None.
    106     """
--> 107     return self._project.query(question, fallback_answer=self._fallback_answer)[0]

File ~/anaconda3/envs/codex/lib/python3.10/site-packages/cleanlab_codex/project.py:176, in Project.query(self, question, fallback_answer, read_only)
    156 def query(
    157     self,
    158     question: str,
   (...)
    161     read_only: bool = False,
    162 ) -> tuple[Optional[str], Optional[Entry]]:
    163     """Query Codex to check if this project contains an answer to the question. Add the question to the project for SME review if it does not.
    164 
    165     Args:
   (...)
    174             If Codex is unable to answer the question, the first element will be `fallback_answer` if provided, otherwise None. The second element will be a new [`Entry`](/reference/python/types.entry#class-entry) in the Codex project.
    175     """
--> 176     return query_project(
    177         client=self._sdk_client,
    178         question=question,
    179         project_id=self.id,
    180         fallback_answer=fallback_answer,
    181         read_only=read_only,
    182     )

File ~/anaconda3/envs/codex/lib/python3.10/site-packages/cleanlab_codex/internal/project.py:35, in query_project(client, question, project_id, fallback_answer, read_only)
     32     return fallback_answer, entry
     34 if not read_only:
---> 35     created_entry = Entry.model_validate(client.projects.entries.add_question(project_id, question=question))
     36     return fallback_answer, created_entry
     38 return fallback_answer, None

File ~/anaconda3/envs/codex/lib/python3.10/site-packages/pydantic/main.py:627, in BaseModel.model_validate(cls, obj, strict, from_attributes, context)
    625 # `__tracebackhide__` tells pytest and some other tools to omit this function from tracebacks
    626 __tracebackhide__ = True
--> 627 return cls.__pydantic_validator__.validate_python(
    628     obj, strict=strict, from_attributes=from_attributes, context=context
    629 )

ValidationError: 1 validation error for Entry
  Input should be a valid dictionary or instance of Entry [type=model_type, input_value=Entry(created_at=datetime...None, frequency_count=0), input_type=Entry]
    For further information visit https://errors.pydantic.dev/2.10/v/model_type
```