### PR TITLE
distinguish between import and package name in error

### DIFF
--- a/src/cleanlab_codex/codex_tool.py
+++ b/src/cleanlab_codex/codex_tool.py
@@ -145,8 +145,9 @@ class CodexTool:
 
         except ImportError as e:
             raise MissingDependencyError(
-                "llama-index-core",
-                "https://docs.llamaindex.ai/en/stable/getting_started/installation/",
+                import_name=e.name or "llama_index",
+                package_name="llama-index-core",
+                package_url="https://docs.llamaindex.ai/en/stable/getting_started/installation/",
             ) from e
 
         return FunctionTool.from_defaults(
@@ -165,7 +166,11 @@ class CodexTool:
             from langchain_core.tools.structured import StructuredTool
 
         except ImportError as e:
-            raise MissingDependencyError("langchain", "https://pypi.org/project/langchain/") from e
+            raise MissingDependencyError(
+                import_name=e.name or "langchain",
+                package_name="langchain",
+                package_url="https://pypi.org/project/langchain/",
+            ) from e
 
         return StructuredTool.from_function(
             func=self.query,

--- a/src/cleanlab_codex/codex_tool.py
+++ b/src/cleanlab_codex/codex_tool.py
@@ -126,7 +126,7 @@ class CodexTool:
         try:
             from cleanlab_codex.utils.smolagents import CodexTool as SmolagentsCodexTool
         except ImportError as e:
-            raise MissingDependencyError("smolagents", "https://github.com/huggingface/smolagents") from e
+            raise MissingDependencyError(e.name or "smolagents", "https://github.com/huggingface/smolagents") from e
 
         return SmolagentsCodexTool(
             query=self.query,

--- a/src/cleanlab_codex/utils/errors.py
+++ b/src/cleanlab_codex/utils/errors.py
@@ -4,12 +4,19 @@ from __future__ import annotations
 class MissingDependencyError(Exception):
     """Raised when a lazy import is missing."""
 
-    def __init__(self, import_name: str, package_url: str | None = None) -> None:
+    def __init__(self, import_name: str, package_name: str | None = None, package_url: str | None = None) -> None:
+        """
+        Args:
+            import_name: The name of the import that failed.
+            package_name: The name of the package to install.
+            package_url: The URL for more information about the package.
+        """
         self.import_name = import_name
+        self.package_name = package_name
         self.package_url = package_url
 
     def __str__(self) -> str:
-        message = f"Failed to import {self.import_name}. Please install the package using `pip install {self.import_name}` and try again."
+        message = f"Failed to import {self.import_name}. Please install the package using `pip install {self.package_name or self.import_name}` and try again."
         if self.package_url:
             message += f" For more information, see {self.package_url}."
         return message


### PR DESCRIPTION
Adds distinction between `import_name` and `package_name` for missing dependency errors on lazy imports to support cases where the imported module name does not match the name of the actual installable package (i.e. `pip install scikit-learn` vs. `import sklearn`) 