### PR TITLE
[CODEX-#369]: Refactor `is_bad_response` to take `TLMOptions` rather than a TLM model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update response validation methods to use the TLM endpoint in the Codex backend rather than a TLM model.
+- Update response validation methods to support accepting and propagating TLMOptions from the cleanlab_tlm library.
+
 ## [1.0.1] - 2025-02-26
 
 - Updates to logic for `is_unhelpful_response` util method.

--- a/src/cleanlab_codex/types/tlm.py
+++ b/src/cleanlab_codex/types/tlm.py
@@ -1,18 +1,17 @@
-from typing import Any, Dict, Protocol, Sequence, Union, runtime_checkable
+"""Types for Codex TLM endpoint."""
+
+from codex.types.tlm_score_response import TlmScoreResponse as _TlmScoreResponse
+
+from cleanlab_codex.internal.utils import generate_class_docstring
 
 
-@runtime_checkable
-class TLM(Protocol):
-    def get_trustworthiness_score(
-        self,
-        prompt: Union[str, Sequence[str]],
-        response: Union[str, Sequence[str]],
-        **kwargs: Any,
-    ) -> Dict[str, Any]: ...
+class TlmScoreResponse(_TlmScoreResponse): ...
 
-    def prompt(
-        self,
-        prompt: Union[str, Sequence[str]],
-        /,
-        **kwargs: Any,
-    ) -> Dict[str, Any]: ...
+
+TlmScoreResponse.__doc__ = f"""
+Type representing a TLM score response in a Codex project. This is the complete data structure returned from the Codex API, including system-generated fields like ID and timestamps.
+
+{generate_class_docstring(_TlmScoreResponse, name=TlmScoreResponse.__name__)}
+"""
+
+__all__ = ["TlmScoreResponse"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,3 @@
-from tests.fixtures.client import mock_client_from_access_key, mock_client_from_api_key
+from tests.fixtures.client import mock_client_from_access_key, mock_client_from_access_key_tlm, mock_client_from_api_key
 
-__all__ = ["mock_client_from_access_key", "mock_client_from_api_key"]
+__all__ = ["mock_client_from_access_key", "mock_client_from_api_key", "mock_client_from_access_key_tlm"]

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -18,3 +18,11 @@ def mock_client_from_api_key() -> Generator[MagicMock, None, None]:
         mock_client = MagicMock()
         mock_init.return_value = mock_client
         yield mock_client
+
+
+@pytest.fixture
+def mock_client_from_access_key_tlm() -> Generator[MagicMock, None, None]:
+    with patch("cleanlab_codex.response_validation.client_from_access_key") as mock_init:
+        mock_client = MagicMock()
+        mock_init.return_value = mock_client
+        yield mock_client


### PR DESCRIPTION

<!-- TODO: Delete anything from this template that doesn't apply -->

## Key Info

- Implementation plan: [link]()
- Priority: normal 
<!-- priority is low, normal, or urgent; for low or urgent, include your expected deadline -->

## What changed?
Changes `is_bad_response` to use Codex TLM pass through instead of requiring a TLM model from the user.

## What do you want the reviewer(s) to focus on?

---

### Checklist

- [x] _Did you link the GitHub issue?_
- [ ] _Did you follow deployment steps or bump the version if needed?_
- [x] _Did you add/update tests?_
- [ ] _What QA did you do?_
  - Tested...
