### PR TITLE
Show scores for different bad response issue-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Extract scores and metadata from detection functions in `response_validation.py`.
+- Normalize scores used by `is_fallback_response` function to be between 0 and 1.
+
 ## [1.0.1] - 2025-02-26
 
 - Updates to logic for `is_unhelpful_response` util method.

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -129,8 +129,8 @@ def is_bad_response(
 ) -> ResponseCheck:
     """Run a series of checks to determine if a response is bad.
 
-    The function returns a `QualityReport` object containing results from multiple validation checks.
-    If any check fails (detects an issue), the QualityReport will evaluate to True when used in a boolean context.
+    The function returns a `ResponseCheck` object containing results from multiple validation checks.
+    If any check fails (detects an issue), the ResponseCheck will evaluate to True when used in a boolean context.
     This means code like `if is_bad_response(...)` will enter the if-block when problems are detected.
 
     For example:

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -103,17 +103,20 @@ def is_bad_response(
     """Run a series of checks to determine if a response is bad.
 
     The function returns a `AggregatedResponseValidationResult` object containing results from multiple validation checks.
-    If any check fails (detects an issue), the AggregatedResponseValidationResult will evaluate to True when used in a boolean context.
+    If any check fails (detects an issue), the AggregatedResponseValidationResult will evaluate to `True` when used in a boolean context.
     This means code like `if is_bad_response(...)` will enter the if-block when problems are detected.
 
     For example:
+    
     ```python
     is_bad = is_bad_response(...)
     if is_bad:  # True if any validation check failed
         print("Response had issues")
         # Access detailed results through is_bad.results
     ```
+    
     This function runs three possible validation checks:
+    
     1. **Fallback check**: Detects if response is too similar to a known fallback answer.
     2. **Untrustworthy check**: Assesses response trustworthiness based on the given context and query.
     3. **Unhelpful check**: Predicts if the response adequately answers the query or not, in a useful way.
@@ -128,7 +131,7 @@ def is_bad_response(
         config (BadResponseDetectionConfig, optional): Optional, configuration parameters for validation checks. See [BadResponseDetectionConfig](#class-badresponsedetectionconfig) for details. If not provided, default values will be used.
 
     Returns:
-        AggregatedResponseValidationResult: A AggregatedResponseValidationResult object containing the results of the validation checks.
+        AggregatedResponseValidationResult: The results of the validation checks.
     """
     config = BadResponseDetectionConfig.model_validate(config)
 
@@ -195,7 +198,7 @@ def is_fallback_response(
                 Higher values require more similarity. Default 0.7 means responses that are 70% or more similar are considered bad.
 
     Returns:
-        SingleResponseValidationResult: A SingleResponseValidationResult object containing the results of the validation checks.
+        SingleResponseValidationResult: The results of the validation check.
     """
 
     score: float = score_fallback_response(response, fallback_answer)
@@ -257,7 +260,7 @@ def is_untrustworthy_response(
                       be evaluated using the same prompt that was used to generate the response.
 
     Returns:
-        SingleResponseValidationResult: A SingleResponseValidationResult object containing the results of the validation checks.
+        SingleResponseValidationResult: The results of the validation check.
     """
     score: float = score_untrustworthy_response(
         response=response,
@@ -281,7 +284,7 @@ def score_untrustworthy_response(
     tlm: TLM,
     format_prompt: Callable[[str, str], str] = default_format_prompt,
 ) -> float:
-    """Scores a response's untrustworthiness using [TLM](/tlm), given a context and query.
+    """Scores a response's trustworthiness using [TLM](/tlm), given a context and query.
 
     Args:
         response (str): The response to check from the assistant.
@@ -293,7 +296,7 @@ def score_untrustworthy_response(
                     be evaluated using the same prompt that was used to generate the response.
 
     Returns:
-        float: The score of the response, between 0.0 and 1.0.
+        float: The score of the response, between 0.0 and 1.0. A lower score indicates the response is less trustworthy.
     """
     try:
         from cleanlab_tlm import TLM  # noqa: F401
@@ -329,7 +332,7 @@ def is_unhelpful_response(
                                        E.g. if confidence_score_threshold is 0.5, then responses with scores higher than 0.5 are considered unhelpful.
 
     Returns:
-        SingleResponseValidationResult: A SingleResponseValidationResult object containing the results of the validation checks.
+        SingleResponseValidationResult: The results of the validation check.
     """
     score: float = score_unhelpful_response(response, query, tlm)
 
@@ -357,7 +360,7 @@ def score_unhelpful_response(
         tlm (TLM): The TLM model to use for evaluation.
 
     Returns:
-        float: The score of the response, between 0.0 and 1.0.
+        float: The score of the response, between 0.0 and 1.0. A higher score corresponds to a less helpful response.
     """
     try:
         from cleanlab_tlm import TLM  # noqa: F401

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -89,6 +89,24 @@ BadResponseDetectionConfig.__doc__ = f"""
 
 _DEFAULT_CONFIG = BadResponseDetectionConfig()
 
+# Type aliases for validation scores
+SingleScoreDict = dict[str, float]
+NestedScoreDict = dict[str, dict[str, float]]
+
+"""Type alias for validation scores.
+
+Scores can be either a single score or a nested dictionary of scores.
+
+Example:
+    # Single score
+    scores: ValidationScores = {"score": 0.5}
+    # Nested scores
+    scores: ValidationScores = {
+        "check_a": {"sub_score_a1": 0.5, "sub_score_a2": 0.5},
+        "check_b": {"sub_score_b1": 0.5, "sub_score_b2": 0.5},
+    }
+"""
+ValidationScores = SingleScoreDict | NestedScoreDict
 
 class ResponseCheck(BaseModel):
     """Result of a response validation check.
@@ -96,13 +114,13 @@ class ResponseCheck(BaseModel):
     Attributes:
         name (Literal["fallback", "untrustworthy", "unhelpful"]): Name of the validation check.
         fails_check (bool): Whether the response fails a given validation check.
-        scores (dict[str, float]): Scores for the response from a given validation check.
+        scores (ValidationScores): Scores for the response from a given validation check.
         metadata (dict[str, Any]): Metadata about the validation check.
     """
 
     name: Literal["bad", "fallback", "untrustworthy", "unhelpful"] = Field(description="Name of the validation check")
     fails_check: bool = Field(description="Whether the response fails a given validation check")
-    scores: dict[str, float] = Field(description="Scores for the response from a given validation check")
+    scores: ValidationScores = Field(description="Scores for the response from a given validation check")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Metadata about the validation check")
 
     def __bool__(self) -> bool:

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -25,7 +25,7 @@ from cleanlab_codex.utils.prompt import default_format_prompt
 _DEFAULT_FALLBACK_ANSWER: str = (
     "Based on the available information, I cannot provide a complete answer to this question."
 )
-_DEFAULT_FALLBACK_SIMILARITY_THRESHOLD: int = 70
+_DEFAULT_FALLBACK_SIMILARITY_THRESHOLD: float = 0.7
 _DEFAULT_TRUSTWORTHINESS_THRESHOLD: float = 0.5
 _DEFAULT_UNHELPFULNESS_CONFIDENCE_THRESHOLD: float = 0.5
 
@@ -47,7 +47,7 @@ class BadResponseDetectionConfig(BaseModel):
         default=_DEFAULT_FALLBACK_ANSWER,
         description="Known unhelpful response to compare against",
     )
-    fallback_similarity_threshold: int = Field(
+    fallback_similarity_threshold: float = Field(
         default=_DEFAULT_FALLBACK_SIMILARITY_THRESHOLD,
         description="Fuzzy matching similarity threshold (0-100). Higher values mean responses must be more similar to fallback_answer to be considered bad.",
         ge=0,
@@ -240,7 +240,7 @@ def is_bad_response(
 def is_fallback_response(
     response: str,
     fallback_answer: str = _DEFAULT_FALLBACK_ANSWER,
-    threshold: int = _DEFAULT_FALLBACK_SIMILARITY_THRESHOLD,
+    threshold: float = _DEFAULT_FALLBACK_SIMILARITY_THRESHOLD,
 ) -> ResponseCheck:
     """Check if a response is too similar to a known fallback answer.
 
@@ -250,8 +250,8 @@ def is_fallback_response(
     Args:
         response (str): The response to check.
         fallback_answer (str): A known unhelpful/fallback response to compare against.
-        threshold (int): Similarity threshold (0-100) above which a response is considered to match the fallback answer.
-                Higher values require more similarity. Default 70 means responses that are 70% or more similar are considered bad.
+        threshold (float): Similarity threshold (0-1.0) above which a response is considered to match the fallback answer.
+                Higher values require more similarity. Default 0.7 means responses that are 70% or more similar are considered bad.
 
     Returns:
         ResponseResult: A ResponseResult object containing the results of the validation checks.
@@ -287,7 +287,7 @@ def score_fallback_response(
             package_url="https://github.com/seatgeek/thefuzz",
         ) from e
 
-    return int(fuzz.partial_ratio(fallback_answer.lower(), response.lower()))
+    return int(fuzz.partial_ratio(fallback_answer.lower(), response.lower())) / 100
 
 
 def is_untrustworthy_response(

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -217,13 +217,24 @@ def is_bad_response(
     scores = {}
     metadata = {}
     fails_check = False
-    for check in validation_checks:
-        response_check = check()
-        scores.update(response_check.scores)
-        metadata.update(response_check.metadata)
-        if response_check.fails_check:
+    _order = []
+    for validation_check_callable in validation_checks:
+        check = validation_check_callable()
+        # Nest the scores and metadata under the check name
+        scores[check.name] = check.scores
+        metadata[check.name] = check.metadata
+
+        # Record the order in which checks were run
+        _order.append(check.name)
+
+        # If any check fails, stop running remaining checks
+        if check.fails_check:
             fails_check = True
             break
+
+    # Add the order of checks to the metadata
+    # Key name is subject to change, use with caution as it may change in the future
+    metadata["_check_order"] = _order
 
     return ResponseCheck(
         name="bad",

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -122,7 +122,7 @@ class ResponseCheck(BaseModel):
         return f"ResponseResult(name={self.name}, {pass_or_fail}, scores={self.scores}{metadata_str})"
 
 
-class ValidationResults(BaseModel):
+class QualityReport(BaseModel):
     """Container for results from multiple validation checks.
 
     Attributes:
@@ -149,11 +149,20 @@ def is_bad_response(
     context: Optional[str] = None,
     query: Optional[str] = None,
     config: Union[BadResponseDetectionConfig, Dict[str, Any]] = _DEFAULT_CONFIG,
-) -> ValidationResults:
+) -> QualityReport:
     """Run a series of checks to determine if a response is bad.
 
-    If any check detects an issue (i.e. fails), the function returns `True`, indicating the response is bad.
+    The function returns a `QualityReport` object containing results from multiple validation checks.
+    If any check fails (detects an issue), the QualityReport will evaluate to True when used in a boolean context.
+    This means code like `if is_bad_response(...)` will enter the if-block when problems are detected.
 
+    For example:
+    ```python
+    is_bad = is_bad_response(...)
+    if is_bad:  # True if any validation check failed
+        print("Response had issues")
+        # Access detailed results through is_bad.results
+    ```
     This function runs three possible validation checks:
     1. **Fallback check**: Detects if response is too similar to a known fallback answer.
     2. **Untrustworthy check**: Assesses response trustworthiness based on the given context and query.
@@ -212,7 +221,7 @@ def is_bad_response(
     # Run all checks in parallel and collect results
     results = asyncio.run(_run_validation_checks(validation_checks))
 
-    return ValidationResults(results=results)
+    return QualityReport(results=results)
 
 
 def is_fallback_response(

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -92,8 +92,7 @@ _DEFAULT_CONFIG = BadResponseDetectionConfig()
 
 # Type aliases for validation scores
 SingleScoreDict = Dict[str, float]
-# In Python 3.8, OrderedDict won't work with generics, so once we drop support for 3.8, we can use NestedScoreDict = OrderedDict[str, SingleScoreDict]
-NestedScoreDict = Dict[str, SingleScoreDict]
+NestedScoreDict = OrderedDict[str, SingleScoreDict]
 
 """Type alias for validation scores.
 

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -398,8 +398,8 @@ def is_unhelpful_response(
     return ResponseCheck(
         name="unhelpful",
         fails_check=score > confidence_score_threshold,
-        scores={"trustworthiness_score": score},
-        metadata={"threshold": confidence_score_threshold},
+        scores={"confidence_score": score},
+        metadata={"confidence_score_threshold": confidence_score_threshold},
     )
 
 

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -195,7 +195,7 @@ def is_bad_response(
             )
         )
 
-    # Run all checks in parallel and collect results
+    # Run all checks and collect results, until one fails
     scores = {}
     metadata = {}
     fails_check = False

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -333,8 +333,8 @@ def is_unhelpful_response(
     """
     score: float = score_unhelpful_response(response, query, tlm)
 
-    # Current implementation assumes question is phrased to expect "Yes" for unhelpful responses
-    # Changing the question would require restructuring this logic and potentially adjusting
+    # Current implementation of `score_unhelpful_response` produces a score where a higher value means the response if more likely to be unhelpful
+    # Changing the TLM prompt used in `score_unhelpful_response` may require restructuring the logic for `fails_check` and potentially adjusting
     # the threshold value in BadResponseDetectionConfig
     return SingleResponseValidationResult(
         name="unhelpful",

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -92,7 +92,8 @@ _DEFAULT_CONFIG = BadResponseDetectionConfig()
 
 # Type aliases for validation scores
 SingleScoreDict = Dict[str, float]
-NestedScoreDict = OrderedDict[str, SingleScoreDict]
+# In Python 3.8, OrderedDict won't work with generics, so once we drop support for 3.8, we can use NestedScoreDict = OrderedDict[str, SingleScoreDict]
+NestedScoreDict = OrderedDict[str, Dict[str, float]]
 
 """Type alias for validation scores.
 
@@ -107,7 +108,7 @@ Example:
         "check_b": {"sub_score_b1": 0.5, "sub_score_b2": 0.5},
     }
 """
-ValidationScores = SingleScoreDict | NestedScoreDict
+ValidationScores = Union[SingleScoreDict, NestedScoreDict]
 
 
 class ResponseCheck(BaseModel):

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -93,7 +93,7 @@ _DEFAULT_CONFIG = BadResponseDetectionConfig()
 # Type aliases for validation scores
 SingleScoreDict = Dict[str, float]
 # In Python 3.8, OrderedDict won't work with generics, so once we drop support for 3.8, we can use NestedScoreDict = OrderedDict[str, SingleScoreDict]
-NestedScoreDict = OrderedDict[str, Dict[str, float]]
+NestedScoreDict = Dict[str, SingleScoreDict]
 
 """Type alias for validation scores.
 

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -177,6 +177,24 @@ def is_fallback_response(
     Returns:
         bool: `True` if the response is too similar to the fallback answer, `False` otherwise.
     """
+
+    score: int = score_fallback_response(response, fallback_answer)
+    return bool(score >= threshold)
+
+
+def score_fallback_response(
+    response: str,
+    fallback_answer: str = _DEFAULT_FALLBACK_ANSWER,
+) -> int:
+    """Score a response against a known fallback answer, based on how similar they are using fuzzy string matching.
+
+    Args:
+        response (str): The response to check.
+        fallback_answer (str): A known unhelpful/fallback response to compare against.
+
+    Returns:
+        int: The score of the response, between 0 and 100.
+    """
     try:
         from thefuzz import fuzz  # type: ignore
     except ImportError as e:
@@ -185,8 +203,7 @@ def is_fallback_response(
             package_url="https://github.com/seatgeek/thefuzz",
         ) from e
 
-    partial_ratio: int = fuzz.partial_ratio(fallback_answer.lower(), response.lower())
-    return bool(partial_ratio >= threshold)
+    return int(fuzz.partial_ratio(fallback_answer.lower(), response.lower()))
 
 
 def is_untrustworthy_response(

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -91,7 +91,7 @@ BadResponseDetectionConfig.__doc__ = f"""
 _DEFAULT_CONFIG = BadResponseDetectionConfig()
 
 # Type aliases for validation scores
-SingleScoreDict = dict[str, float]
+SingleScoreDict = Dict[str, float]
 NestedScoreDict = OrderedDict[str, SingleScoreDict]
 
 """Type alias for validation scores.
@@ -117,13 +117,13 @@ class ResponseCheck(BaseModel):
         name (Literal["fallback", "untrustworthy", "unhelpful"]): Name of the validation check.
         fails_check (bool): Whether the response fails a given validation check.
         scores (ValidationScores): Scores for the response from a given validation check.
-        metadata (dict[str, Any]): Metadata about the validation check.
+        metadata (Dict[str, Any]): Metadata about the validation check.
     """
 
     name: Literal["bad", "fallback", "untrustworthy", "unhelpful"] = Field(description="Name of the validation check")
     fails_check: bool = Field(description="Whether the response fails a given validation check")
     scores: ValidationScores = Field(description="Scores for the response from a given validation check")
-    metadata: dict[str, Any] = Field(default_factory=dict, description="Metadata about the validation check")
+    metadata: Dict[str, Any] = Field(default_factory=dict, description="Metadata about the validation check")
 
     def __bool__(self) -> bool:
         """Convert ResponseResult to bool.

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -107,16 +107,16 @@ def is_bad_response(
     This means code like `if is_bad_response(...)` will enter the if-block when problems are detected.
 
     For example:
-    
+
     ```python
     is_bad = is_bad_response(...)
     if is_bad:  # True if any validation check failed
         print("Response had issues")
         # Access detailed results through is_bad.results
     ```
-    
+
     This function runs three possible validation checks:
-    
+
     1. **Fallback check**: Detects if response is too similar to a known fallback answer.
     2. **Untrustworthy check**: Assesses response trustworthiness based on the given context and query.
     3. **Unhelpful check**: Predicts if the response adequately answers the query or not, in a useful way.

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -51,9 +51,9 @@ class BadResponseDetectionConfig(BaseModel):
     )
     fallback_similarity_threshold: float = Field(
         default=_DEFAULT_FALLBACK_SIMILARITY_THRESHOLD,
-        description="Fuzzy matching similarity threshold (0-100). Higher values mean responses must be more similar to fallback_answer to be considered bad.",
-        ge=0,
-        le=100,
+        description="Fuzzy matching similarity threshold (0.0-1.0). Higher values mean responses must be more similar to fallback_answer to be considered bad.",
+        ge=0.0,
+        le=1.0,
     )
 
     # Untrustworthy check config

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -226,6 +226,7 @@ def is_bad_response(
         score_dict = cast(SingleScoreDict, check.scores)
         scores[check.name] = score_dict
         metadata[check.name] = check.metadata
+        metadata[check.name]["fails_check"] = check.fails_check
 
         # If any check fails, stop running remaining checks
         if check.fails_check:

--- a/src/cleanlab_codex/types/response_validation.py
+++ b/src/cleanlab_codex/types/response_validation.py
@@ -46,10 +46,10 @@ class SingleResponseValidationResult(BaseResponseValidationResult):
         return self.fails_check
 
     def __repr__(self) -> str:
-        """Return a string representation of the ResponseResult."""
+        """Return a string representation of the SingleResponseValidationResult."""
         pass_or_fail = "Passed Check" if self.fails_check else "Failed Check"
         metadata_str = ", metadata=..." if self.metadata else ""
-        return f"ResponseResult(name={self.name}, {pass_or_fail}, score={self.score}{metadata_str})"
+        return f"SingleResponseValidationResult(name={self.name}, {pass_or_fail}, score={self.score}{metadata_str})"
 
 
 class AggregatedResponseValidationResult(BaseResponseValidationResult):

--- a/src/cleanlab_codex/types/response_validation.py
+++ b/src/cleanlab_codex/types/response_validation.py
@@ -1,0 +1,70 @@
+from abc import ABC, abstractmethod
+from collections import OrderedDict
+from typing import Any, Dict, List, Literal, Union
+
+from pydantic import BaseModel, computed_field
+
+# Type aliases for validation scores
+SingleScoreDict = Dict[str, float]
+NestedScoreDict = OrderedDict[str, SingleScoreDict]
+
+"""Type alias for validation scores.
+
+Scores can be either a single score or a nested dictionary of scores.
+
+Example:
+    # Single score
+    scores: ValidationScores = {"score": 0.5}
+    # Nested scores
+    scores: ValidationScores = {
+        "check_a": {"sub_score_a1": 0.5, "sub_score_a2": 0.5},
+        "check_b": {"sub_score_b1": 0.5, "sub_score_b2": 0.5},
+    }
+"""
+ValidationScores = Union[SingleScoreDict, NestedScoreDict]
+
+
+ResponseValidationMethod = Literal["fallback", "untrustworthy", "unhelpful"]
+AggregatedResponseValidationMethod = Literal["bad"]
+
+
+class BaseResponseValidationResult(BaseModel, ABC):
+    name: Union[ResponseValidationMethod, AggregatedResponseValidationMethod]
+
+    @abstractmethod
+    def __bool__(self) -> bool:
+        raise NotImplementedError
+
+
+class SingleResponseValidationResult(BaseResponseValidationResult):
+    name: ResponseValidationMethod
+    fails_check: bool
+    score: Dict[str, float]
+    metadata: Dict[str, Any]
+
+    def __bool__(self) -> bool:
+        return self.fails_check
+
+    def __repr__(self) -> str:
+        """Return a string representation of the ResponseResult."""
+        pass_or_fail = "Passed Check" if self.fails_check else "Failed Check"
+        metadata_str = ", metadata=..." if self.metadata else ""
+        return f"ResponseResult(name={self.name}, {pass_or_fail}, score={self.score}{metadata_str})"
+
+
+class AggregatedResponseValidationResult(BaseResponseValidationResult):
+    name: AggregatedResponseValidationMethod
+    results: List[SingleResponseValidationResult]
+
+    @computed_field  # type: ignore
+    @property
+    def fails_check(self) -> bool:
+        return any(result.fails_check for result in self.results)
+
+    def __bool__(self) -> bool:
+        return self.fails_check
+
+    def __repr__(self) -> str:
+        """Return a string representation of the AggregatedResponseValidationResult."""
+        pass_or_fail = "Passed Check" if self.fails_check else "Failed Check"
+        return f"AggregatedResponseValidationResult(name={self.name}, {pass_or_fail}, results={self.results})"

--- a/src/cleanlab_codex/types/response_validation.py
+++ b/src/cleanlab_codex/types/response_validation.py
@@ -47,7 +47,7 @@ class SingleResponseValidationResult(BaseResponseValidationResult):
 
     def __repr__(self) -> str:
         """Return a string representation of the SingleResponseValidationResult."""
-        pass_or_fail = "Passed Check" if self.fails_check else "Failed Check"
+        pass_or_fail = "Failed Check" if self.fails_check else "Passed Check"
         metadata_str = ", metadata=..." if self.metadata else ""
         return f"SingleResponseValidationResult(name={self.name}, {pass_or_fail}, score={self.score}{metadata_str})"
 

--- a/src/cleanlab_codex/types/response_validation.py
+++ b/src/cleanlab_codex/types/response_validation.py
@@ -46,7 +46,7 @@ class SingleResponseValidationResult(BaseResponseValidationResult):
     name: ResponseValidationMethod = Field(description="The name of the validation check.")
     fails_check: bool = Field(description="Whether the check failed. True if the check failed, False otherwise.")
     score: Dict[str, float] = Field(
-        description="The score of the response. Typically a single scorevalue between 0.0 and 1.0, yet this can vary by check."
+        description="The score of the response. Typically a single score's value is between 0.0 and 1.0, but this can vary by check."
     )
     metadata: Dict[str, Any] = Field(
         description="Additional metadata about the response. This can include the threshold values, or other information relevant to the check."

--- a/src/cleanlab_codex/types/response_validation.py
+++ b/src/cleanlab_codex/types/response_validation.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from collections import OrderedDict
 from typing import Any, Dict, List, Literal, Union
 
-from pydantic import BaseModel, computed_field, Field
+from pydantic import BaseModel, Field, computed_field
 
 # Type aliases for validation scores
 SingleScoreDict = Dict[str, float]
@@ -42,10 +42,9 @@ class SingleResponseValidationResult(BaseResponseValidationResult):
     This class represents the outcome of an individual validation check performed
     on an AI response.
     """
+
     name: ResponseValidationMethod = Field(description="The name of the validation check.")
-    fails_check: bool = Field(
-        description="Whether the check failed. True if the check failed, False otherwise."
-    )
+    fails_check: bool = Field(description="Whether the check failed. True if the check failed, False otherwise.")
     score: Dict[str, float] = Field(
         description="The score of the response. Typically a single scorevalue between 0.0 and 1.0, yet this can vary by check."
     )
@@ -64,7 +63,7 @@ class SingleResponseValidationResult(BaseResponseValidationResult):
 
 class AggregatedResponseValidationResult(BaseResponseValidationResult):
     """Result of multiple combined response validation checks.
-    
+
     This class aggregates multiple SingleResponseValidationResults and provides
     a combined validation outcome.
 
@@ -73,9 +72,7 @@ class AggregatedResponseValidationResult(BaseResponseValidationResult):
     accessible, via the `results` field.
     """
 
-    name: AggregatedResponseValidationMethod = Field(
-        description="The name of the aggregated validation check."
-    )
+    name: AggregatedResponseValidationMethod = Field(description="The name of the aggregated validation check.")
     results: List[SingleResponseValidationResult] = Field(
         description="The individual results of the validation checks."
     )

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -13,6 +13,7 @@ from cleanlab_codex.response_validation import (
     is_fallback_response,
     is_unhelpful_response,
     is_untrustworthy_response,
+    score_fallback_response,
 )
 
 # Mock responses for testing
@@ -221,3 +222,20 @@ def test_is_bad_response_partial_inputs(
             )
             is expected
         )
+
+
+@pytest.mark.parametrize(
+    ("response", "fallback_answer", "expected"),
+    [
+        ("This is a test response", "This is a test response", 100),  # exact match
+        ("abcd", "Abcd", 100),  # same response, different case
+        ("This is a test response", "This is a test answer", 86),  # similar response
+        ("This is a test response", "A totally different fallback answer", 39),  # different response
+        ("abcd", "efgh", 0),  # no characters in common
+        ("abcd", "dcba", 40),  # reverse order
+        ("don't know", "I don't know", 100),  # partial match
+        ("I don't know", "don't know", 100),  # partial match, response longer than fallback
+    ],
+)
+def test_score_fallback_response(response: str, fallback_answer: str, expected: int) -> None:
+    assert score_fallback_response(response, fallback_answer) == expected

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -14,6 +14,7 @@ from cleanlab_codex.response_validation import (
     is_unhelpful_response,
     is_untrustworthy_response,
     score_fallback_response,
+    score_unhelpful_response,
     score_untrustworthy_response,
 )
 
@@ -254,4 +255,34 @@ def test_score_fallback_response(response: str, fallback_answer: str, expected: 
 def test_score_untrustworthy_response(mock_tlm: Mock, tlm_score: float) -> None:
     """Test score_untrustworthy_response function."""
     mock_tlm.get_trustworthiness_score = Mock(return_value={"trustworthiness_score": tlm_score})
-    assert score_untrustworthy_response(BAD_RESPONSE, CONTEXT, QUERY, mock_tlm) == tlm_score
+    assert (
+        score_untrustworthy_response(
+            response="A response",
+            context="Some context",
+            query="A query",
+            tlm=mock_tlm,
+        )
+        == tlm_score
+    )
+
+
+@pytest.mark.parametrize(
+    ("tlm_score"),
+    [
+        (0.5),
+        (0.8),
+        (0.3),
+        (0.0),
+    ],
+)
+def test_score_unhelpful_response(mock_tlm: Mock, tlm_score: float) -> None:
+    """Test score_unhelpful_response function."""
+    mock_tlm.get_trustworthiness_score = Mock(return_value={"trustworthiness_score": tlm_score})
+    assert (
+        score_unhelpful_response(
+            response="A response",
+            query="A query",
+            tlm=mock_tlm,
+        )
+        == tlm_score
+    )

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -14,6 +14,7 @@ from cleanlab_codex.response_validation import (
     is_unhelpful_response,
     is_untrustworthy_response,
     score_fallback_response,
+    score_untrustworthy_response,
 )
 
 # Mock responses for testing
@@ -239,3 +240,18 @@ def test_is_bad_response_partial_inputs(
 )
 def test_score_fallback_response(response: str, fallback_answer: str, expected: int) -> None:
     assert score_fallback_response(response, fallback_answer) == expected
+
+
+@pytest.mark.parametrize(
+    ("tlm_score"),
+    [
+        (0.5),
+        (0.8),
+        (0.3),
+        (0.0),
+    ],
+)
+def test_score_untrustworthy_response(mock_tlm: Mock, tlm_score: float) -> None:
+    """Test score_untrustworthy_response function."""
+    mock_tlm.get_trustworthiness_score = Mock(return_value={"trustworthiness_score": tlm_score})
+    assert score_untrustworthy_response(BAD_RESPONSE, CONTEXT, QUERY, mock_tlm) == tlm_score

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -316,6 +316,15 @@ class TestSingleResponseValidationResult:
         result.fails_check = False
         assert not bool(result)
 
+    def test_repr(self) -> None:
+        result = SingleResponseValidationResult(
+            name="fallback", fails_check=True, score={"similarity_score": 0.5}, metadata={"context": "Some context"}
+        )
+        assert "Failed Check" in repr(result)
+
+        result.fails_check = False
+        assert "Passed Check" in repr(result)
+
     def test_invalid_name(self) -> None:
         from pydantic_core import ValidationError
 

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -9,7 +9,7 @@ import pytest
 
 from cleanlab_codex.response_validation import (
     _DEFAULT_UNHELPFULNESS_CONFIDENCE_THRESHOLD,
-    ResponseResult,
+    ResponseCheck,
     is_bad_response,
     is_fallback_response,
     is_unhelpful_response,
@@ -297,7 +297,7 @@ class TestResponseResult:
     def test_response_result_init(self) -> None:
         for name in ["fallback", "untrustworthy", "unhelpful"]:
             for fails_check in [True, False]:
-                result = ResponseResult(
+                result = ResponseCheck(
                     name=name,  # type: ignore
                     fails_check=fails_check,
                     scores={"similarity_score": 0.5},
@@ -309,7 +309,7 @@ class TestResponseResult:
                 assert result.metadata == {"context": "Some context"}
 
     def test_bool_conversion(self) -> None:
-        result = ResponseResult(
+        result = ResponseCheck(
             name="fallback", fails_check=True, scores={"similarity_score": 0.5}, metadata={"context": "Some context"}
         )
         assert bool(result)
@@ -320,7 +320,7 @@ class TestResponseResult:
         from pydantic_core import ValidationError
 
         with pytest.raises(ValidationError):
-            ResponseResult(
+            ResponseCheck(
                 name="invalid",  # type: ignore
                 fails_check=True,
                 scores={},

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -295,7 +295,7 @@ def test_score_unhelpful_response(mock_tlm: Mock, tlm_score: float) -> None:
 
 class TestResponseResult:
     def test_response_result_init(self) -> None:
-        for name in ["fallback", "untrustworthy", "unhelpful"]:
+        for name in ["bad", "fallback", "untrustworthy", "unhelpful"]:
             for fails_check in [True, False]:
                 result = ResponseCheck(
                     name=name,  # type: ignore

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -72,14 +72,14 @@ def mock_tlm() -> MockTLM:
     ("response", "threshold", "fallback_answer", "expected"),
     [
         # Test threshold variations
-        (GOOD_RESPONSE, 30, None, True),
-        (GOOD_RESPONSE, 55, None, False),
+        (GOOD_RESPONSE, 0.3, None, True),
+        (GOOD_RESPONSE, 0.55, None, False),
         # Test default behavior (BAD_RESPONSE should be flagged)
         (BAD_RESPONSE, None, None, True),
         # Test default behavior for different response (GOOD_RESPONSE should not be flagged)
         (GOOD_RESPONSE, None, None, False),
         # Test custom fallback answer
-        (GOOD_RESPONSE, 80, "This is an unhelpful response", False),
+        (GOOD_RESPONSE, 0.8, "This is an unhelpful response", False),
     ],
 )
 def test_is_fallback_response(
@@ -234,14 +234,14 @@ def test_is_bad_response_partial_inputs(
 @pytest.mark.parametrize(
     ("response", "fallback_answer", "expected"),
     [
-        ("This is a test response", "This is a test response", 100),  # exact match
-        ("abcd", "Abcd", 100),  # same response, different case
-        ("This is a test response", "This is a test answer", 86),  # similar response
-        ("This is a test response", "A totally different fallback answer", 39),  # different response
-        ("abcd", "efgh", 0),  # no characters in common
-        ("abcd", "dcba", 40),  # reverse order
-        ("don't know", "I don't know", 100),  # partial match
-        ("I don't know", "don't know", 100),  # partial match, response longer than fallback
+        ("This is a test response", "This is a test response", 1.0),  # exact match
+        ("abcd", "Abcd", 1.0),  # same response, different case
+        ("This is a test response", "This is a test answer", 0.86),  # similar response
+        ("This is a test response", "A totally different fallback answer", 0.39),  # different response
+        ("abcd", "efgh", 0.0),  # no characters in common
+        ("abcd", "dcba", 0.4),  # reverse order
+        ("don't know", "I don't know", 1.0),  # partial match
+        ("I don't know", "don't know", 1.0),  # partial match, response longer than fallback
     ],
 )
 def test_score_fallback_response(response: str, fallback_answer: str, expected: int) -> None:


### PR DESCRIPTION
## Key Info

- Implementation plan: [link](https://www.notion.so/cleanlab/909904115407492a8f44e180dd481c8a?v=15ec7fee85be8045b708000c4a7fc0e1&p=1a6c7fee85be8084be37ee9349193d0b&pm=s)
- Priority: Urgent, March 4th. 

## What changed?

- Each `is_x_response` function (except `is_bad_response`) is now split into a function that handles the scoring logic and a separate function that handles the detection aspect.
- Each `is_x_response` function now returns a `is_bad: ResponseCheck` object that stores the scores as well as the result of the check (along with any relevant metadata if necessary). It implements a `__bool__` method so it works well with existing tutorials.
- The scores for `is_fallback_response` have been normalized to lie in the range 0-1 (like the others). The rest of the functions already have their scores normalized to the same range.


## What do you want the reviewer(s) to focus on?

- Take a look at the type aliases defined early in `src/cleanlab_codex/response_validation.py`. These are defined mainly to make it clearer why the scores dictionary provided by `is_bad_response` nests other dictionaries, while the functions just return the flat dictionaries. Suggest better names for these aliases.
- ~I'm fine with renaming `ResponseCheck` to something else. It's important that it can be evaluated like a boolean. IMO, adding an `is_bad` property doesn't make much sense with the current usage of these functions.~ Split into two classes now and with improved names for these validation results: `AggregatedResponseValidationResult` and `SingleResponseValidationResult`
- Most of the tests focus on the behavior of the scoring functions, as well as the validation result classes. 

---

### Checklist

- [x] _Did you link the GitHub issue?_
- [ ] _Did you follow deployment steps or bump the version if needed?_
- [x] _Did you add/update tests?_
- [x] _What QA did you do?_
  - Tested the [`CodexAsBackupOptions` tutorial](https://help.cleanlab.ai/codex/tutorials/advanced/CodexAsBackupOptions/). Everything behaves the same way, except that a threshold set in [this section](https://help.cleanlab.ai/codex/tutorials/advanced/CodexAsBackupOptions/#detect-fallback-responses) must be updated separately from this PR.

---

### Example

This is taken from our existing [CodexAsBackupOptions tutorial](https://help.cleanlab.ai/codex/tutorials/advanced/CodexAsBackupOptions/#detect-all-sorts-of-bad-responses):

```python
from cleanlab_codex.response_validation import is_bad_response

response, context = rag(query)

is_bad = is_bad_response(
    response,
    # Optional arguments below
    context=context,                        # Context used by RAG
    query=query,                            # Original user query
    config={
        "tlm": tlm,                         # Use TLM to evaluate the response
        "format_prompt": format_prompt,     # Your prompt formatting function
    }
)

if is_bad:  # See if Codex has an answer
    codex_response, _ = codex_project.query(
        query,
        fallback_answer=fallback_answer,
    )
    if codex_response:  # Codex was able to answer
        response = codex_response
        # Note: in conversational rather than single-turn Q&A applications, you additionally should overwrite response <- codex_response in the chat message history before returning the overwritten response.

print(response)
# Return it within 30 days for a full refund-- no questions asked. Contact our support team to initiate your return!
```

But now `is_bad` is no longer just a boolean:

```python
is_bad
# AggregatedResponseValidationResult(name=bad, Passed Check, results=[SingleResponseValidationResult(name=fallback, Passed Check, score={'similarity_score': 0.69}, metadata=...), SingleResponseValidationResult(name=untrustworthy, Failed Check, score={'trustworthiness_score': 0.2621560628947528}, metadata=...)])


is_bad.result
# [SingleResponseValidationResult(name=fallback, Passed Check, score={'similarity_score': 0.69}, metadata=...),
#  SingleResponseValidationResult(name=untrustworthy, Failed Check, score={'trustworthiness_score': 0.2621560628947528}, metadata=...)]

bool(is_bad)
# True
```

