### PR TITLE
drop support for py3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,16 @@ jobs:
   typecheck:
     name: Type check
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
       - uses: pypa/hatch@install
-      - run: hatch run types:check
+      - run: hatch run types.py${{ matrix.python}}:check
   fmt:
     name: Format and lint
     runs-on: ubuntu-24.04
@@ -34,7 +37,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "cleanlab-codex"
 dynamic = ["version"]
 description = 'Python client library for developers to integrate Cleanlab Codex into RAG systems'
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "MIT"
 keywords = []
 authors = [
@@ -16,11 +16,11 @@ authors = [
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
@@ -43,13 +43,18 @@ extra-dependencies = [
   "mypy>=1.0.0",
   "pytest",
   "llama-index-core",
-  "smolagents",
+  "smolagents; python_version >= '3.10'",
   "cleanlab-tlm",
   "thefuzz",
   "langchain-core",
 ]
+
+[[tool.hatch.envs.types.matrix]]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+
 [tool.hatch.envs.types.scripts]
 check = "mypy --strict --install-types --non-interactive {args:src/cleanlab_codex tests}"
+
 [tool.hatch.metadata]
 allow-direct-references = true
 


### PR DESCRIPTION
## Key Info

## What changed?
- dropped support for python 3.8 since this package depends on `cleanlab-tlm` which doesn't support python 3.8
- updates CI to run type checking for all supported python versions

## What do you want the reviewer(s) to focus on?

---

### Checklist

- [ ] _Did you link the GitHub issue?_
- [ ] _Did you follow deployment steps or bump the version if needed?_
- [ ] _Did you add/update tests?_
- [ ] _What QA did you do?_
  - Tested...
