### PR TITLE
update response validation to use TLM via Codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3] - 2025-03-11
+
+- Update response validation methods for Codex as backup to use TLM through Codex API instead of requiring separate TLM API key.
+
 ## [1.0.2] - 2025-03-07
 
 - Extract scores and metadata from detection functions in `response_validation.py`.
@@ -21,7 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `cleanlab-codex` client library.
 
-[Unreleased]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.2...HEAD
+[Unreleased]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.3...HEAD
+[1.0.3]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/cleanlab/cleanlab-codex/compare/267a93300f77c94e215d7697223931e7926cad9e...v1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "codex-sdk@git+https://github.com/stainless-sdks/codex-python.git@axl1313/dev",
+  "codex-sdk==0.1.0a12",
   "pydantic>=2.0.0, <3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,8 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "codex-sdk==0.1.0a9",
+  "codex-sdk@git+https://github.com/stainless-sdks/codex-python.git@axl1313/dev",
   "pydantic>=2.0.0, <3",
-  "cleanlab-tlm",
 ]
 
 [project.urls]
@@ -44,7 +43,6 @@ extra-dependencies = [
   "pytest",
   "llama-index-core",
   "smolagents; python_version >= '3.10'",
-  "cleanlab-tlm",
   "thefuzz",
   "langchain-core",
 ]
@@ -62,7 +60,6 @@ allow-direct-references = true
 extra-dependencies = [
   "llama-index-core",
   "smolagents; python_version >= '3.10'",
-  "cleanlab-tlm",
   "thefuzz",
   "langchain-core",
 ]

--- a/src/cleanlab_codex/__about__.py
+++ b/src/cleanlab_codex/__about__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: MIT
-__version__ = "1.0.2"
+__version__ = "1.0.3"

--- a/src/cleanlab_codex/internal/tlm.py
+++ b/src/cleanlab_codex/internal/tlm.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from cleanlab_codex.internal.sdk_client import client_from_access_key
+from cleanlab_codex.types.tlm import (
+    TLMConfig,
+    TLMOptions,
+    TLMPromptResponse,
+    TLMQualityPreset,
+    TLMScoreResponse,
+)
+
+
+class TLM:
+    def __init__(
+        self,
+        quality_preset: Optional[TLMQualityPreset] = None,
+        *,
+        task: Optional[str] = None,
+        options: Optional[TLMOptions] = None,
+        codex_access_key: Optional[str] = None,
+    ):
+        self._sdk_client = client_from_access_key(key=codex_access_key)
+        self._tlm_kwargs: Dict[str, Any] = {}
+        if quality_preset:
+            self._tlm_kwargs["quality_preset"] = quality_preset
+        if task:
+            self._tlm_kwargs["task"] = task
+        if options:
+            self._tlm_kwargs["options"] = options
+
+    @classmethod
+    def from_config(cls, config: TLMConfig, *, codex_access_key: Optional[str] = None) -> TLM:
+        return cls(**config.model_dump(), codex_access_key=codex_access_key)
+
+    def prompt(
+        self,
+        prompt: str,
+        *,
+        constrain_outputs: Optional[List[str]] = None,
+    ) -> TLMPromptResponse:
+        return TLMPromptResponse.model_validate(
+            self._sdk_client.tlm.prompt(
+                prompt=prompt,
+                constrain_outputs=constrain_outputs,
+                **self._tlm_kwargs,
+            ).model_dump()
+        )
+
+    def get_trustworthiness_score(
+        self,
+        prompt: str,
+        response: str,
+        *,
+        constrain_outputs: Optional[List[str]] = None,
+    ) -> TLMScoreResponse:
+        return TLMScoreResponse.model_validate(
+            self._sdk_client.tlm.score(
+                prompt=prompt,
+                response=response,
+                constrain_outputs=constrain_outputs,
+                **self._tlm_kwargs,
+            ).model_dump()
+        )

--- a/src/cleanlab_codex/internal/tlm.py
+++ b/src/cleanlab_codex/internal/tlm.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from cleanlab_codex.internal.sdk_client import client_from_access_key
+from cleanlab_codex.internal.sdk_client import (
+    MissingAuthKeyError,
+    client_from_access_key,
+    client_from_api_key,
+)
 from cleanlab_codex.types.tlm import (
     TLMConfig,
     TLMOptions,
@@ -21,7 +25,11 @@ class TLM:
         options: Optional[TLMOptions] = None,
         codex_access_key: Optional[str] = None,
     ):
-        self._sdk_client = client_from_access_key(key=codex_access_key)
+        try:
+            self._sdk_client = client_from_access_key(key=codex_access_key)
+        except MissingAuthKeyError:
+            self._sdk_client = client_from_api_key()
+
         self._tlm_kwargs: Dict[str, Any] = {}
         if quality_preset:
             self._tlm_kwargs["quality_preset"] = quality_preset

--- a/src/cleanlab_codex/internal/utils.py
+++ b/src/cleanlab_codex/internal/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING as _TYPE_CHECKING
 
+from pydantic_core import PydanticUndefinedType
 from typing_extensions import get_origin, get_type_hints, is_typeddict
 
 if _TYPE_CHECKING:
@@ -59,7 +60,7 @@ def format_annotation_from_field_info(field_name: str, field_info: FieldInfo) ->
     annotation = field_name
     if field_info.annotation:
         annotation += f": '{annotation_to_str(field_info.annotation)}'"
-    if field_info.default:
+    if field_info.default and not isinstance(field_info.default, PydanticUndefinedType):
         annotation += f" = {field_info.default}"
     return annotation
 

--- a/src/cleanlab_codex/internal/utils.py
+++ b/src/cleanlab_codex/internal/utils.py
@@ -40,7 +40,7 @@ def generate_pydantic_model_docstring(cls: type[BaseModel], name: str) -> str:
     formatted_annotations = "\n    ".join(
         format_annotation_from_field_info(field_name, field_info) for field_name, field_info in cls.model_fields.items()
     )
-    formatted_fields = "\n  ".join(
+    formatted_fields = "\n".join(
         format_pydantic_field_docstring(field_name, field_info) for field_name, field_info in cls.model_fields.items()
     )
     return f"""

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -15,12 +15,13 @@ from typing import (
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from cleanlab_codex.internal.tlm import TLM
 from cleanlab_codex.internal.utils import generate_pydantic_model_docstring
 from cleanlab_codex.types.response_validation import (
     AggregatedResponseValidationResult,
     SingleResponseValidationResult,
 )
-from cleanlab_codex.types.tlm import TLM
+from cleanlab_codex.types.tlm import TLMConfig
 from cleanlab_codex.utils.errors import MissingDependencyError
 from cleanlab_codex.utils.prompt import default_format_prompt
 
@@ -30,6 +31,7 @@ _DEFAULT_FALLBACK_ANSWER: str = (
 _DEFAULT_FALLBACK_SIMILARITY_THRESHOLD: float = 0.7
 _DEFAULT_TRUSTWORTHINESS_THRESHOLD: float = 0.5
 _DEFAULT_UNHELPFULNESS_CONFIDENCE_THRESHOLD: float = 0.5
+_DEFAULT_TLM_CONFIG: TLMConfig = TLMConfig()
 
 Query = str
 Context = str
@@ -77,13 +79,12 @@ class BadResponseDetectionConfig(BaseModel):
     )
 
     # Shared config (for untrustworthiness and unhelpfulness checks)
-    tlm: Optional[TLM] = Field(
-        default=None,
-        description="TLM model to use for evaluation (required for untrustworthiness and unhelpfulness checks).",
+    tlm_config: TLMConfig = Field(
+        default=_DEFAULT_TLM_CONFIG,
+        description="TLM model configuration to use for untrustworthiness and unhelpfulness checks.",
     )
 
 
-# hack to generate better documentation for help.cleanlab.ai
 BadResponseDetectionConfig.__doc__ = f"""
 {BadResponseDetectionConfig.__doc__}
 
@@ -99,6 +100,7 @@ def is_bad_response(
     context: Optional[str] = None,
     query: Optional[str] = None,
     config: Union[BadResponseDetectionConfig, Dict[str, Any]] = _DEFAULT_CONFIG,
+    codex_access_key: Optional[str] = None,
 ) -> AggregatedResponseValidationResult:
     """Run a series of checks to determine if a response is bad.
 
@@ -146,7 +148,7 @@ def is_bad_response(
         )
     )
 
-    can_run_untrustworthy_check = query is not None and context is not None and config.tlm is not None
+    can_run_untrustworthy_check = query is not None and context is not None and config.tlm_config is not None
     if can_run_untrustworthy_check:
         # The if condition guarantees these are not None
         validation_checks.append(
@@ -154,20 +156,22 @@ def is_bad_response(
                 response=response,
                 context=cast(str, context),
                 query=cast(str, query),
-                tlm=cast(TLM, config.tlm),
+                tlm_config=config.tlm_config,
                 trustworthiness_threshold=config.trustworthiness_threshold,
                 format_prompt=config.format_prompt,
+                codex_access_key=codex_access_key,
             )
         )
 
-    can_run_unhelpful_check = query is not None and config.tlm is not None
+    can_run_unhelpful_check = query is not None and config.tlm_config is not None
     if can_run_unhelpful_check:
         validation_checks.append(
             lambda: is_unhelpful_response(
                 response=response,
                 query=cast(str, query),
-                tlm=cast(TLM, config.tlm),
+                tlm_config=config.tlm_config,
                 confidence_score_threshold=config.unhelpfulness_confidence_threshold,
+                codex_access_key=codex_access_key,
             )
         )
 
@@ -238,9 +242,11 @@ def is_untrustworthy_response(
     response: str,
     context: str,
     query: str,
-    tlm: TLM,
+    tlm_config: TLMConfig = _DEFAULT_TLM_CONFIG,
     trustworthiness_threshold: float = _DEFAULT_TRUSTWORTHINESS_THRESHOLD,
     format_prompt: Callable[[str, str], str] = default_format_prompt,
+    *,
+    codex_access_key: Optional[str] = None,
 ) -> SingleResponseValidationResult:
     """Check if a response is untrustworthy.
 
@@ -252,7 +258,7 @@ def is_untrustworthy_response(
         response (str): The response to check from the assistant.
         context (str): The context information available for answering the query.
         query (str): The user's question or request.
-        tlm (TLM): The TLM model to use for evaluation.
+        tlm_config (TLMConfig): The TLM configuration to use for evaluation.
         trustworthiness_threshold (float): Score threshold (0.0-1.0) under which a response is considered untrustworthy.
                   Lower values allow less trustworthy responses. Default 0.5 means responses with scores less than 0.5 are considered untrustworthy.
         format_prompt (Callable[[str, str], str]): Function that takes (query, context) and returns a formatted prompt string.
@@ -266,8 +272,9 @@ def is_untrustworthy_response(
         response=response,
         context=context,
         query=query,
-        tlm=tlm,
+        tlm_config=tlm_config,
         format_prompt=format_prompt,
+        codex_access_key=codex_access_key,
     )
     return SingleResponseValidationResult(
         name="untrustworthy",
@@ -281,8 +288,10 @@ def score_untrustworthy_response(
     response: str,
     context: str,
     query: str,
-    tlm: TLM,
+    tlm_config: TLMConfig = _DEFAULT_TLM_CONFIG,
     format_prompt: Callable[[str, str], str] = default_format_prompt,
+    *,
+    codex_access_key: Optional[str] = None,
 ) -> float:
     """Scores a response's trustworthiness using [TLM](/tlm), given a context and query.
 
@@ -298,24 +307,20 @@ def score_untrustworthy_response(
     Returns:
         float: The score of the response, between 0.0 and 1.0. A lower score indicates the response is less trustworthy.
     """
-    try:
-        from cleanlab_tlm import TLM  # noqa: F401
-    except ImportError as e:
-        raise MissingDependencyError(
-            import_name=e.name or "cleanlab_tlm",
-            package_name="cleanlab-tlm",
-            package_url="https://github.com/cleanlab/cleanlab-tlm",
-        ) from e
     prompt = format_prompt(query, context)
-    result = tlm.get_trustworthiness_score(prompt, response)
-    return float(result["trustworthiness_score"])
+    result = TLM.from_config(tlm_config, codex_access_key=codex_access_key).get_trustworthiness_score(
+        prompt, response=response
+    )
+    return float(result.trustworthiness_score)
 
 
 def is_unhelpful_response(
     response: str,
     query: str,
-    tlm: TLM,
+    tlm_config: TLMConfig = _DEFAULT_TLM_CONFIG,
     confidence_score_threshold: float = _DEFAULT_UNHELPFULNESS_CONFIDENCE_THRESHOLD,
+    *,
+    codex_access_key: Optional[str] = None,
 ) -> SingleResponseValidationResult:
     """Check if a response is unhelpful by asking [TLM](/tlm) to evaluate it.
 
@@ -327,14 +332,14 @@ def is_unhelpful_response(
     Args:
         response (str): The response to check.
         query (str): User query that will be used to evaluate if the response is helpful.
-        tlm (TLM): The TLM model to use for evaluation.
+        tlm_config (TLMConfig): The configuration
         confidence_score_threshold (float): Confidence threshold (0.0-1.0) above which a response is considered unhelpful.
                                        E.g. if confidence_score_threshold is 0.5, then responses with scores higher than 0.5 are considered unhelpful.
 
     Returns:
         SingleResponseValidationResult: The results of the validation check.
     """
-    score: float = score_unhelpful_response(response, query, tlm)
+    score: float = score_unhelpful_response(response, query, tlm_config, codex_access_key=codex_access_key)
 
     # Current implementation of `score_unhelpful_response` produces a score where a higher value means the response if more likely to be unhelpful
     # Changing the TLM prompt used in `score_unhelpful_response` may require restructuring the logic for `fails_check` and potentially adjusting
@@ -350,27 +355,20 @@ def is_unhelpful_response(
 def score_unhelpful_response(
     response: str,
     query: str,
-    tlm: TLM,
+    tlm_config: TLMConfig = _DEFAULT_TLM_CONFIG,
+    *,
+    codex_access_key: Optional[str] = None,
 ) -> float:
     """Scores a response's unhelpfulness using [TLM](/tlm), given a query.
 
     Args:
         response (str): The response to check.
         query (str): User query that will be used to evaluate if the response is helpful.
-        tlm (TLM): The TLM model to use for evaluation.
+        tlm_config (TLMConfig): The TLM model to use for evaluation.
 
     Returns:
         float: The score of the response, between 0.0 and 1.0. A higher score corresponds to a less helpful response.
     """
-    try:
-        from cleanlab_tlm import TLM  # noqa: F401
-    except ImportError as e:
-        raise MissingDependencyError(
-            import_name=e.name or "cleanlab_tlm",
-            package_name="cleanlab-tlm",
-            package_url="https://github.com/cleanlab/cleanlab-tlm",
-        ) from e
-
     # IMPORTANT: The current implementation couples three things that must stay in sync:
     # 1. The question phrasing ("is unhelpful?")
     # 2. The expected_unhelpful_response ("Yes")
@@ -405,5 +403,7 @@ def score_unhelpful_response(
         f"AI Assistant Response: {response}\n\n"
         f"{question}"
     )
-    result = tlm.get_trustworthiness_score(prompt, response=expected_unhelpful_response)
-    return float(result["trustworthiness_score"])
+    result = TLM.from_config(tlm_config, codex_access_key=codex_access_key).get_trustworthiness_score(
+        prompt, response=expected_unhelpful_response
+    )
+    return float(result.trustworthiness_score)

--- a/src/cleanlab_codex/response_validation.py
+++ b/src/cleanlab_codex/response_validation.py
@@ -104,7 +104,7 @@ def is_bad_response(
 ) -> AggregatedResponseValidationResult:
     """Run a series of checks to determine if a response is bad.
 
-    The function returns a `AggregatedResponseValidationResult` object containing results from multiple validation checks.
+    The function returns an `AggregatedResponseValidationResult` object containing results from multiple validation checks.
     If any check fails (detects an issue), the AggregatedResponseValidationResult will evaluate to `True` when used in a boolean context.
     This means code like `if is_bad_response(...)` will enter the if-block when problems are detected.
 

--- a/src/cleanlab_codex/types/response_validation.py
+++ b/src/cleanlab_codex/types/response_validation.py
@@ -1,3 +1,5 @@
+"""Types for response validation."""
+
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from typing import Any, Dict, List, Literal, Union

--- a/src/cleanlab_codex/types/response_validation.py
+++ b/src/cleanlab_codex/types/response_validation.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Literal, Union
 
 from pydantic import BaseModel, Field, computed_field
 
+from cleanlab_codex.internal.utils import generate_pydantic_model_docstring
+
 # Type aliases for validation scores
 SingleScoreDict = Dict[str, float]
 NestedScoreDict = OrderedDict[str, SingleScoreDict]
@@ -63,6 +65,13 @@ class SingleResponseValidationResult(BaseResponseValidationResult):
         return f"SingleResponseValidationResult(name={self.name}, {pass_or_fail}, score={self.score}{metadata_str})"
 
 
+SingleResponseValidationResult.__doc__ = f"""
+{SingleResponseValidationResult.__doc__}
+
+{generate_pydantic_model_docstring(SingleResponseValidationResult, name=SingleResponseValidationResult.__name__)}
+"""
+
+
 class AggregatedResponseValidationResult(BaseResponseValidationResult):
     """Result of multiple combined response validation checks.
 
@@ -91,3 +100,10 @@ class AggregatedResponseValidationResult(BaseResponseValidationResult):
     def __repr__(self) -> str:
         pass_or_fail = "Passed Check" if self.fails_check else "Failed Check"
         return f"AggregatedResponseValidationResult(name={self.name}, {pass_or_fail}, results={self.results})"
+
+
+AggregatedResponseValidationResult.__doc__ = f"""
+{AggregatedResponseValidationResult.__doc__}
+
+{generate_pydantic_model_docstring(AggregatedResponseValidationResult, name=AggregatedResponseValidationResult.__name__)}
+"""

--- a/src/cleanlab_codex/types/tlm.py
+++ b/src/cleanlab_codex/types/tlm.py
@@ -1,18 +1,64 @@
-from typing import Any, Dict, Protocol, Sequence, Union, runtime_checkable
+from typing import Literal, Optional
+
+from codex.types.tlm_prompt_params import Options
+from codex.types.tlm_prompt_response import TlmPromptResponse as _TlmPromptResponse
+from codex.types.tlm_score_response import TlmScoreResponse as _TlmScoreResponse
+from pydantic import BaseModel, Field
+
+from cleanlab_codex.internal.utils import generate_class_docstring, generate_pydantic_model_docstring
+
+TLMQualityPreset = Literal["best", "high", "medium", "low", "base"]
 
 
-@runtime_checkable
-class TLM(Protocol):
-    def get_trustworthiness_score(
-        self,
-        prompt: Union[str, Sequence[str]],
-        response: Union[str, Sequence[str]],
-        **kwargs: Any,
-    ) -> Dict[str, Any]: ...
+class TLMOptions(Options): ...
 
-    def prompt(
-        self,
-        prompt: Union[str, Sequence[str]],
-        /,
-        **kwargs: Any,
-    ) -> Dict[str, Any]: ...
+
+TLMOptions.__doc__ = f"""
+Customization options for querying TLM. For details, see the [TLM documentation](/tlm/api/python/tlm/#class-tlmoptions)
+
+{generate_class_docstring(Options, name=TLMOptions.__name__)}
+"""
+
+
+class TLMPromptResponse(_TlmPromptResponse): ...
+
+
+TLMPromptResponse.__doc__ = f"""
+The response from prompting TLM.
+
+{generate_class_docstring(_TlmPromptResponse, name=TLMPromptResponse.__name__)}
+"""
+
+
+class TLMScoreResponse(_TlmScoreResponse): ...
+
+
+TLMScoreResponse.__doc__ = f"""
+The result of scoring a response with TLM.
+
+{generate_class_docstring(_TlmScoreResponse, name=TLMScoreResponse.__name__)}
+"""
+
+
+class TLMConfig(BaseModel):
+    """Advanced configuration options for the TLM client."""
+
+    quality_preset: Optional[TLMQualityPreset] = Field(
+        default=None,
+        description="See [TLM documentation for more information](https://docs.cleanlab.ai/reference/tlm/api/python/tlm/#class-tlm).",
+    )
+    task: Optional[str] = Field(
+        default=None,
+        description="See [TLM documentation for more information](https://docs.cleanlab.ai/reference/tlm/api/python/tlm/#class-tlm).",
+    )
+    options: Optional[TLMOptions] = Field(
+        default=None,
+        description="See [TLM documentation for more information](https://docs.cleanlab.ai/reference/tlm/api/python/tlm/#class-tlmoptions).",
+    )
+
+
+TLMConfig.__doc__ = f"""
+{TLMConfig.__doc__}
+
+{generate_pydantic_model_docstring(TLMConfig, name=TLMConfig.__name__)}
+"""

--- a/src/cleanlab_codex/types/tlm.py
+++ b/src/cleanlab_codex/types/tlm.py
@@ -16,7 +16,7 @@ class TLMOptions(Options): ...
 
 
 TLMOptions.__doc__ = f"""
-Customization options for querying TLM. For details, see the [TLM documentation](/tlm/api/python/tlm/#class-tlmoptions)
+Customization options for querying TLM. For details, see the [TLM documentation](/tlm/api/python/tlm/#class-tlmoptions).
 
 {generate_class_docstring(Options, name=TLMOptions.__name__)}
 """
@@ -47,15 +47,15 @@ class TLMConfig(BaseModel):
 
     quality_preset: Optional[TLMQualityPreset] = Field(
         default=None,
-        description="See [TLM documentation for more information](https://docs.cleanlab.ai/reference/tlm/api/python/tlm/#class-tlm).",
+        description="See [TLM documentation for more information](/tlm/api/python/tlm/#class-tlm).",
     )
     task: Optional[str] = Field(
         default=None,
-        description="See [TLM documentation for more information](https://docs.cleanlab.ai/reference/tlm/api/python/tlm/#class-tlm).",
+        description="See [TLM documentation for more information](/tlm/api/python/tlm/#class-tlm).",
     )
     options: Optional[TLMOptions] = Field(
         default=None,
-        description="See [TLM documentation for more information](https://docs.cleanlab.ai/reference/tlm/api/python/tlm/#class-tlmoptions).",
+        description="See [TLM documentation for more information](/tlm/api/python/tlm/#class-tlmoptions).",
     )
 
 

--- a/src/cleanlab_codex/types/tlm.py
+++ b/src/cleanlab_codex/types/tlm.py
@@ -1,3 +1,5 @@
+"""Types for TLM."""
+
 from typing import Literal, Optional
 
 from codex.types.tlm_prompt_params import Options

--- a/src/cleanlab_codex/types/tlm.py
+++ b/src/cleanlab_codex/types/tlm.py
@@ -43,19 +43,19 @@ The result of scoring a response with TLM.
 
 
 class TLMConfig(BaseModel):
-    """Advanced configuration options for the TLM client."""
+    """Advanced configuration options for TLM."""
 
     quality_preset: Optional[TLMQualityPreset] = Field(
         default=None,
-        description="See [TLM documentation for more information](/tlm/api/python/tlm/#class-tlm).",
+        description="See [TLM documentation for more information](/tlm/api/python/tlm/#class-tlm). If not provided, the default preset used is 'low'.",
     )
     task: Optional[str] = Field(
         default=None,
-        description="See [TLM documentation for more information](/tlm/api/python/tlm/#class-tlm).",
+        description="See [TLM documentation for more information](/tlm/api/python/tlm/#class-tlm). If not provided, the default task used is 'default'.",
     )
     options: Optional[TLMOptions] = Field(
         default=None,
-        description="See [TLM documentation for more information](/tlm/api/python/tlm/#class-tlmoptions).",
+        description="See [TLM documentation for more information](/tlm/api/python/tlm/#class-tlmoptions) (including defaults).",
     )
 
 

--- a/tests/test_response_validation.py
+++ b/tests/test_response_validation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Sequence, Union
+from typing import Any, Generator, Sequence, Union
 from unittest.mock import Mock, patch
 
 import pytest
@@ -17,7 +17,11 @@ from cleanlab_codex.response_validation import (
     score_unhelpful_response,
     score_untrustworthy_response,
 )
-from cleanlab_codex.types.response_validation import AggregatedResponseValidationResult, SingleResponseValidationResult
+from cleanlab_codex.types.response_validation import (
+    AggregatedResponseValidationResult,
+    SingleResponseValidationResult,
+)
+from cleanlab_codex.types.tlm import TLMConfig, TLMPromptResponse, TLMScoreResponse
 
 # Mock responses for testing
 GOOD_RESPONSE = "This is a helpful and specific response that answers the question completely."
@@ -51,21 +55,24 @@ class MockTLM(Mock):
         prompt: Union[str, Sequence[str]],  # noqa: ARG002
         response: Union[str, Sequence[str]],  # noqa: ARG002
         **kwargs: Any,  # noqa: ARG002
-    ) -> Dict[str, Any]:
-        return {"trustworthiness_score": self._trustworthiness_score}
+    ) -> TLMScoreResponse:
+        return TLMScoreResponse(trustworthiness_score=self._trustworthiness_score)
 
     def prompt(
         self,
         prompt: Union[str, Sequence[str]],  # noqa: ARG002
         /,
         **kwargs: Any,  # noqa: ARG002
-    ) -> Dict[str, Any]:
-        return {"response": self._response, "trustworthiness_score": self._trustworthiness_score}
+    ) -> TLMPromptResponse:
+        return TLMPromptResponse(trustworthiness_score=self._trustworthiness_score, response=self._response)
 
 
 @pytest.fixture
-def mock_tlm() -> MockTLM:
-    return MockTLM()
+def mock_tlm_client() -> Generator[Mock, None, None]:
+    with patch("cleanlab_codex.response_validation.TLM.from_config") as mock_tlm_from_config:
+        mock_tlm = MockTLM()
+        mock_tlm_from_config.return_value = mock_tlm
+        yield mock_tlm
 
 
 @pytest.mark.parametrize(
@@ -99,15 +106,23 @@ def test_is_fallback_response(
     assert bool(is_fallback_response(response, **kwargs)) == expected  # type: ignore
 
 
-def test_is_untrustworthy_response(mock_tlm: Mock) -> None:
+def test_is_untrustworthy_response(mock_tlm_client: Mock) -> None:
     """Test untrustworthy response detection."""
     # Test trustworthy response
-    mock_tlm.trustworthiness_score = 0.8
-    assert not bool(is_untrustworthy_response(GOOD_RESPONSE, CONTEXT, QUERY, mock_tlm, trustworthiness_threshold=0.5))
+    mock_tlm_client.trustworthiness_score = 0.8
+    assert not bool(
+        is_untrustworthy_response(
+            GOOD_RESPONSE,
+            CONTEXT,
+            QUERY,
+            mock_tlm_client,
+            trustworthiness_threshold=0.5,
+        )
+    )
 
     # Test untrustworthy response
-    mock_tlm.trustworthiness_score = 0.3
-    assert bool(is_untrustworthy_response(BAD_RESPONSE, CONTEXT, QUERY, mock_tlm, trustworthiness_threshold=0.5))
+    mock_tlm_client.trustworthiness_score = 0.3
+    assert bool(is_untrustworthy_response(BAD_RESPONSE, CONTEXT, QUERY, mock_tlm_client, trustworthiness_threshold=0.5))
 
 
 @pytest.mark.parametrize(
@@ -123,12 +138,16 @@ def test_is_untrustworthy_response(mock_tlm: Mock) -> None:
         # Default threshold tests
         (0.4, None, False),  # Below default
         (_DEFAULT_UNHELPFULNESS_CONFIDENCE_THRESHOLD, None, False),  # At default
-        (_DEFAULT_UNHELPFULNESS_CONFIDENCE_THRESHOLD + 0.01, None, True),  # Just above default
+        (
+            _DEFAULT_UNHELPFULNESS_CONFIDENCE_THRESHOLD + 0.01,
+            None,
+            True,
+        ),  # Just above default
         (0.7, None, True),  # Above default
     ],
 )
 def test_is_unhelpful_response(
-    mock_tlm: Mock,
+    mock_tlm_client: Mock,
     tlm_score: float,
     threshold: float | None,
     *,
@@ -140,13 +159,13 @@ def test_is_unhelpful_response(
     This may seem counter-intuitive, but higher scores indicate more similar responses to
     known unhelpful patterns.
     """
-    mock_tlm.trustworthiness_score = tlm_score
+    mock_tlm_client.trustworthiness_score = tlm_score
 
     # The response content doesn't affect the result, only the score matters
     if threshold is not None:
-        result = is_unhelpful_response(GOOD_RESPONSE, QUERY, mock_tlm, confidence_score_threshold=threshold)
+        result = is_unhelpful_response(GOOD_RESPONSE, QUERY, mock_tlm_client, confidence_score_threshold=threshold)
     else:
-        result = is_unhelpful_response(GOOD_RESPONSE, QUERY, mock_tlm)
+        result = is_unhelpful_response(GOOD_RESPONSE, QUERY, mock_tlm_client)
 
     assert bool(result) == expected_unhelpful
 
@@ -161,7 +180,7 @@ def test_is_unhelpful_response(
     ],
 )
 def test_is_bad_response(
-    mock_tlm: Mock,
+    mock_tlm_client: Mock,
     response: str,
     trustworthiness_score: float,
     prompt_score: float,
@@ -170,11 +189,13 @@ def test_is_bad_response(
 ) -> None:
     """Test the main is_bad_response function."""
     # Create a new Mock object for get_trustworthiness_score
-    mock_tlm.get_trustworthiness_score = Mock(return_value={"trustworthiness_score": trustworthiness_score})
+    mock_tlm_client.get_trustworthiness_score = Mock()
     # Set up the second call to return prompt_score
-    mock_tlm.get_trustworthiness_score.side_effect = [
-        {"trustworthiness_score": trustworthiness_score},  # Should be called by is_untrustworthy_response
-        {"trustworthiness_score": prompt_score},  # Should be called by is_unhelpful_response
+    mock_tlm_client.get_trustworthiness_score.side_effect = [
+        # Should be called by is_untrustworthy_response
+        TLMScoreResponse(trustworthiness_score=trustworthiness_score),
+        # Should be called by is_unhelpful_response
+        TLMScoreResponse(trustworthiness_score=prompt_score),
     ]
 
     assert (
@@ -183,7 +204,7 @@ def test_is_bad_response(
                 response,
                 context=CONTEXT,
                 query=QUERY,
-                config={"tlm": mock_tlm},
+                config={"tlm": mock_tlm_client},
             )
         )
         == expected
@@ -191,23 +212,22 @@ def test_is_bad_response(
 
 
 @pytest.mark.parametrize(
-    ("response", "fuzz_ratio", "prompt_score", "query", "tlm", "expected"),
+    ("response", "fuzz_ratio", "prompt_score", "query", "expected"),
     [
         # Test with only fallback check (no context/query/tlm)
-        (BAD_RESPONSE, 90, None, None, None, True),
+        (BAD_RESPONSE, 90, None, None, True),
         # Test with fallback and unhelpful checks (no context)
-        (GOOD_RESPONSE, 30, 0.1, QUERY, "mock_tlm", False),
+        (GOOD_RESPONSE, 30, 0.1, QUERY, False),
         # Test with fallback and unhelpful checks (with context) (prompt_score is above threshold)
-        (GOOD_RESPONSE, 30, 0.6, QUERY, "mock_tlm", True),
+        (GOOD_RESPONSE, 30, 0.6, QUERY, True),
     ],
 )
 def test_is_bad_response_partial_inputs(
-    mock_tlm: Mock,
+    mock_tlm_client: Mock,
     response: str,
     fuzz_ratio: int,
     prompt_score: float,
     query: str,
-    tlm: Mock,
     *,
     expected: bool,
 ) -> None:
@@ -216,19 +236,11 @@ def test_is_bad_response_partial_inputs(
     mock_fuzz.partial_ratio.return_value = fuzz_ratio
     with patch.dict("sys.modules", {"thefuzz": Mock(fuzz=mock_fuzz)}):
         if prompt_score is not None:
-            mock_tlm.trustworthiness_score = prompt_score
-            tlm = mock_tlm
-
-        assert (
-            bool(
-                is_bad_response(
-                    response,
-                    query=query,
-                    config={"tlm": tlm},
-                )
+            mock_tlm_client.get_trustworthiness_score = Mock(
+                return_value=TLMScoreResponse(trustworthiness_score=prompt_score)
             )
-            == expected
-        )
+
+        assert bool(is_bad_response(response, query=query)) == expected
 
 
 @pytest.mark.parametrize(
@@ -237,11 +249,19 @@ def test_is_bad_response_partial_inputs(
         ("This is a test response", "This is a test response", 1.0),  # exact match
         ("abcd", "Abcd", 1.0),  # same response, different case
         ("This is a test response", "This is a test answer", 0.86),  # similar response
-        ("This is a test response", "A totally different fallback answer", 0.39),  # different response
+        (
+            "This is a test response",
+            "A totally different fallback answer",
+            0.39,
+        ),  # different response
         ("abcd", "efgh", 0.0),  # no characters in common
         ("abcd", "dcba", 0.4),  # reverse order
         ("don't know", "I don't know", 1.0),  # partial match
-        ("I don't know", "don't know", 1.0),  # partial match, response longer than fallback
+        (
+            "I don't know",
+            "don't know",
+            1.0,
+        ),  # partial match, response longer than fallback
     ],
 )
 def test_score_fallback_response(response: str, fallback_answer: str, expected: int) -> None:
@@ -257,15 +277,15 @@ def test_score_fallback_response(response: str, fallback_answer: str, expected: 
         (0.0),
     ],
 )
-def test_score_untrustworthy_response(mock_tlm: Mock, tlm_score: float) -> None:
+def test_score_untrustworthy_response(mock_tlm_client: Mock, tlm_score: float) -> None:
     """Test score_untrustworthy_response function."""
-    mock_tlm.get_trustworthiness_score = Mock(return_value={"trustworthiness_score": tlm_score})
+    mock_tlm_client.get_trustworthiness_score = Mock(return_value=TLMScoreResponse(trustworthiness_score=tlm_score))
     assert (
         score_untrustworthy_response(
             response="A response",
             context="Some context",
             query="A query",
-            tlm=mock_tlm,
+            tlm_config=mock_tlm_client,
         )
         == tlm_score
     )
@@ -280,14 +300,14 @@ def test_score_untrustworthy_response(mock_tlm: Mock, tlm_score: float) -> None:
         (0.0),
     ],
 )
-def test_score_unhelpful_response(mock_tlm: Mock, tlm_score: float) -> None:
+def test_score_unhelpful_response(mock_tlm_client: Mock, tlm_score: float) -> None:
     """Test score_unhelpful_response function."""
-    mock_tlm.get_trustworthiness_score = Mock(return_value={"trustworthiness_score": tlm_score})
+    mock_tlm_client.get_trustworthiness_score = Mock(return_value=TLMScoreResponse(trustworthiness_score=tlm_score))
     assert (
         score_unhelpful_response(
             response="A response",
             query="A query",
-            tlm=mock_tlm,
+            tlm_config=TLMConfig(),
         )
         == tlm_score
     )
@@ -310,7 +330,10 @@ class TestSingleResponseValidationResult:
 
     def test_bool_conversion(self) -> None:
         result = SingleResponseValidationResult(
-            name="fallback", fails_check=True, score={"similarity_score": 0.5}, metadata={"context": "Some context"}
+            name="fallback",
+            fails_check=True,
+            score={"similarity_score": 0.5},
+            metadata={"context": "Some context"},
         )
         assert bool(result)
         result.fails_check = False
@@ -318,7 +341,10 @@ class TestSingleResponseValidationResult:
 
     def test_repr(self) -> None:
         result = SingleResponseValidationResult(
-            name="fallback", fails_check=True, score={"similarity_score": 0.5}, metadata={"context": "Some context"}
+            name="fallback",
+            fails_check=True,
+            score={"similarity_score": 0.5},
+            metadata={"context": "Some context"},
         )
         assert "Failed Check" in repr(result)
 
@@ -342,7 +368,10 @@ class TestAggregatedResponseValidationResult:
     @pytest.fixture
     def fallback_result(self) -> SingleResponseValidationResult:
         return SingleResponseValidationResult(
-            name="fallback", fails_check=True, score={"similarity_score": 0.5}, metadata={"context": "Some context"}
+            name="fallback",
+            fails_check=True,
+            score={"similarity_score": 0.5},
+            metadata={"context": "Some context"},
         )
 
     def test_aggregated_response_validation_result_init(self, fallback_result: SingleResponseValidationResult) -> None:
@@ -356,7 +385,10 @@ class TestAggregatedResponseValidationResult:
         assert bool(result)
 
         failed_single_response_result = SingleResponseValidationResult(
-            name="fallback", fails_check=False, score={"similarity_score": 0.5}, metadata={"context": "Some context"}
+            name="fallback",
+            fails_check=False,
+            score={"similarity_score": 0.5},
+            metadata={"context": "Some context"},
         )
         result = AggregatedResponseValidationResult(
             name="bad",


### PR DESCRIPTION
## What changed?
- Updates response validation methods to use TLM through Codex instead of using TLM directly (so that users don't need to create a TLM account separately).
- As part of this change, updates `BadResponseDetectionConfig` to take in an TLM Config instead of `TLM` instance.
  - The reason for this change rather than just adding an implementation of the TLM Protocol is because the interface for `TLM.get_confidence_score()` and `TLM.prompt()` is messy to match. The score and prompt methods in `cleanlab-tlm` support providing either single inputs or batch inputs and returning single results or batch results appropriately. This means that the TLM Protocol we previously defined actually did not match the typing of `TLM` from `cleanlab-tlm` library.

Closes https://github.com/cleanlab/codex/issues/369

### Checklist

- [x] _Did you link the GitHub issue?_
- [x] _Did you follow deployment steps or bump the version if needed?_
- [x] _Did you add/update tests?_
- [x] _What QA did you do?_
  - Tested w/ updated tutorials in https://github.com/cleanlab/cleanlab-studio-docs/pull/857
