### PR TITLE
Add validator module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
+  "cleanlab-tlm>=1.0.12",
   "codex-sdk==0.1.0a12",
   "pydantic>=2.0.0, <3",
 ]

--- a/src/cleanlab_codex/__init__.py
+++ b/src/cleanlab_codex/__init__.py
@@ -2,5 +2,6 @@
 from cleanlab_codex.client import Client
 from cleanlab_codex.codex_tool import CodexTool
 from cleanlab_codex.project import Project
+from cleanlab_codex.validator import Validator
 
-__all__ = ["Client", "CodexTool", "Project"]
+__all__ = ["Client", "CodexTool", "Project", "Validator"]

--- a/src/cleanlab_codex/internal/validator.py
+++ b/src/cleanlab_codex/internal/validator.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from cleanlab_codex.utils.errors import MissingDependencyError
+
+try:
+    from cleanlab_tlm.utils.rag import Eval, TrustworthyRAGScore, get_default_evals
+except ImportError as e:
+    raise MissingDependencyError(
+        import_name=e.name or "cleanlab-tlm",
+        package_url="https://github.com/cleanlab/cleanlab-tlm",
+    ) from e
+
+
+"""Evaluation metrics (excluding trustworthiness) that are used to determine if a response is bad."""
+EVAL_METRICS = ["response_helpfulness"]
+
+"""Evaluation metrics that are used to determine if a response is bad."""
+BAD_RESPONSE_EVAL_METRICS = ["trustworthiness", *EVAL_METRICS]
+
+
+class IsBadResponseConfig(BaseModel):
+    """Config for determining if a response is bad.
+    Each key is an evaluation metric and the value is a threshold such that if the score is below the threshold, the response is bad.
+    """
+
+    trustworthiness: float = Field(
+        description="Threshold for trustworthiness. If the score is below this threshold, the response is bad.",
+        default=0.5,
+        ge=0,
+        le=1,
+    )
+    response_helpfulness: float = Field(
+        description="Threshold for response helpfulness. If the score is below this threshold, the response is bad.",
+        default=0.5,
+        ge=0,
+        le=1,
+    )
+
+
+def get_default_evaluations() -> list[Eval]:
+    """Get the default evaluations for the TrustworthyRAG.
+
+    Note:
+        This excludes trustworthiness, which is automatically computed by TrustworthyRAG.
+    """
+    return [evaluation for evaluation in get_default_evals() if evaluation.name in EVAL_METRICS]
+
+
+DEFAULT_IS_BAD_RESPONSE_CONFIG: IsBadResponseConfig = IsBadResponseConfig(
+    trustworthiness=0.5,
+    response_helpfulness=0.5,
+)
+
+
+DEFAULT_TRUSTWORTHYRAG_CONFIG = {
+    "options": {
+        "log": ["explanation"],
+    },
+}
+
+
+def get_default_trustworthyrag_config() -> dict[str, Any]:
+    """Get the default configuration for the TrustworthyRAG."""
+    return DEFAULT_TRUSTWORTHYRAG_CONFIG
+
+
+def is_bad_response(scores: TrustworthyRAGScore, is_bad_response_config: IsBadResponseConfig | None = None) -> bool:
+    """
+    Check if the response is bad based on the scores computed by TrustworthyRAG and the config containing thresholds.
+    """
+    is_bad_response_config_dict: dict[str, float] = IsBadResponseConfig.model_validate(
+        is_bad_response_config or DEFAULT_IS_BAD_RESPONSE_CONFIG
+    ).model_dump()
+    for eval_metric in BAD_RESPONSE_EVAL_METRICS:
+        score = scores[eval_metric]["score"]
+        if score is None:
+            error_msg = f"Score for {eval_metric} is None"
+            raise ValueError(error_msg)
+        threshold = is_bad_response_config_dict[eval_metric]
+        if score < threshold:
+            return True
+    return False

--- a/src/cleanlab_codex/validator.py
+++ b/src/cleanlab_codex/validator.py
@@ -1,0 +1,113 @@
+"""
+Leverage Cleanlab's Evals and Codex to detect and remediate bad responses in RAG applications.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, cast
+
+from cleanlab_codex.internal.validator import (
+    IsBadResponseConfig,
+    get_default_evaluations,
+    get_default_trustworthyrag_config,
+)
+from cleanlab_codex.internal.validator import is_bad_response as _is_bad_response
+from cleanlab_codex.project import Project
+from cleanlab_codex.utils.errors import MissingDependencyError
+
+try:
+    from cleanlab_tlm import TrustworthyRAG
+    from cleanlab_tlm.utils.rag import TrustworthyRAGScore
+except ImportError as e:
+    raise MissingDependencyError(
+        import_name=e.name or "cleanlab-tlm",
+        package_url="https://github.com/cleanlab/cleanlab-tlm",
+    ) from e
+
+
+class Validator:
+    def __init__(
+        self,
+        codex_access_key: str,
+        tlm_api_key: Optional[str] = None,
+        trustworthy_rag_config: Optional[dict[str, Any]] = None,
+        is_bad_response_config: Optional[dict[str, float]] = None,
+    ):
+        """Evaluates the quality of responses generated in RAG applications and remediates them if needed.
+
+        This object combines Cleanlab's various Evals with thresholding to detect bad responses and remediates them with Codex.
+
+        Args:
+            codex_access_key (str): The [access key](/codex/web_tutorials/create_project/#access-keys) for a Codex project.
+            tlm_api_key (Optional[str]): The API key for [TrustworthyRAG](/tlm/api/python/utils.rag/#class-trustworthyrag).
+            trustworthy_rag_config (Optional[dict[str, Any]]): The constructor arguments for [TrustworthyRAG](/tlm/api/python/utils.rag/#class-trustworthyrag).
+            is_bad_response_config (Optional[dict[str, float]]): The configuration for determining if a response is bad.
+        """
+        trustworthy_rag_config = trustworthy_rag_config or get_default_trustworthyrag_config()
+        if tlm_api_key is not None:
+            trustworthy_rag_config["api_key"] = tlm_api_key
+        self._is_bad_response_config = IsBadResponseConfig.model_validate(is_bad_response_config or {})
+
+        self._project: Project = Project.from_access_key(access_key=codex_access_key)
+
+        trustworthy_rag_config.setdefault("evals", get_default_evaluations())
+        self._tlm_rag = TrustworthyRAG(**trustworthy_rag_config)
+
+    def validate(self, query: str, context: str, response: str) -> dict[str, Any]:
+        """Validate the response quality and generate an alternative response if needed.
+
+        Args:
+            query (str): The user's original query.
+            context (str): The context provided to generate the response.
+            response (str): The response to evaluate.
+
+        Returns:
+            dict[str, Any]: A dictionary containing:
+                - 'is_bad_response': True if the response is determined to be bad, False otherwise.
+                - 'alt_answer': The alternative response from Codex, or None if no response could be fetched from Codex.
+                - Other evaluation metrics from TrustworthyRAG.
+        """
+        scores, is_bad_response = self.detect(query, context, response)
+        alt_answer = None
+        if is_bad_response:
+            alt_answer = self.remediate(query)
+
+        return {
+            "is_bad_response": is_bad_response,
+            "alt_answer": alt_answer,
+            **scores,
+        }
+
+    def detect(self, query: str, context: str, response: str) -> tuple[TrustworthyRAGScore, bool]:
+        """Evaluate the response quality using TrustworthyRAG and determine if it is a bad response.
+
+        Args:
+            query (str): The user's original query.
+            context (str): The context provided to generate the response.
+            response (str): The response to evaluate.
+
+        Returns:
+            tuple[TrustworthyRAGScore, bool]: A tuple containing:
+                - TrustworthyRAGScore: Quality scores for different evaluation metrics like trustworthiness
+                  and response helpfulness. Each metric has a score between 0-1.
+                - bool: True if the response is determined to be bad based on the evaluation scores
+                  and configured thresholds, False otherwise.
+        """
+        scores = cast(TrustworthyRAGScore, self._tlm_rag.score(response=response, query=query, context=context))
+        _config = (
+            IsBadResponseConfig.model_validate(self._is_bad_response_config) if self._is_bad_response_config else None
+        )
+        is_bad_response = _is_bad_response(scores, _config)
+        return scores, is_bad_response
+
+    def remediate(self, query: str) -> str | None:
+        """Queries Codex to get an alternative response when the original response is determined to be bad.
+
+        Args:
+            query (str): The user's original query to get an alternative response for.
+
+        Returns:
+            str | None: The alternative response from Codex, or None if no response could be fetched from Codex.
+        """
+        codex_answer, _ = self._project.query(question=query)
+        return codex_answer

--- a/tests/internal/test_validator.py
+++ b/tests/internal/test_validator.py
@@ -1,0 +1,55 @@
+from typing import cast
+
+import pytest
+from cleanlab_tlm.utils.rag import TrustworthyRAGScore
+
+from cleanlab_codex.internal.validator import IsBadResponseConfig, get_default_evaluations, is_bad_response
+
+
+def make_scores(trustworthiness: float, response_helpfulness: float) -> TrustworthyRAGScore:
+    scores = {
+        "trustworthiness": {
+            "score": trustworthiness,
+        },
+        "response_helpfulness": {
+            "score": response_helpfulness,
+        },
+    }
+    return cast(TrustworthyRAGScore, scores)
+
+
+def make_is_bad_response_config(trustworthiness: float, response_helpfulness: float) -> IsBadResponseConfig:
+    return IsBadResponseConfig(
+        trustworthiness=trustworthiness,
+        response_helpfulness=response_helpfulness,
+    )
+
+
+def test_get_default_evaluations() -> None:
+    assert {evaluation.name for evaluation in get_default_evaluations()} == {"response_helpfulness"}
+
+
+class TestIsBadResponse:
+    @pytest.fixture
+    def scores(self) -> TrustworthyRAGScore:
+        return make_scores(0.92, 0.75)
+
+    @pytest.fixture
+    def custom_is_bad_response_config(self) -> IsBadResponseConfig:
+        return make_is_bad_response_config(0.6, 0.7)
+
+    def test_thresholds(self, scores: TrustworthyRAGScore) -> None:
+        default_is_bad_response = is_bad_response(scores)
+        assert not default_is_bad_response
+
+        # High trustworthiness_threshold
+        is_bad_response_config = make_is_bad_response_config(0.921, 0.5)
+        assert is_bad_response(scores, is_bad_response_config)
+
+        # High response_helpfulness_threshold
+        is_bad_response_config = make_is_bad_response_config(0.5, 0.751)
+        assert is_bad_response(scores, is_bad_response_config)
+
+    def test_scores(self, custom_is_bad_response_config: IsBadResponseConfig) -> None:
+        scores = make_scores(0.59, 0.7)
+        assert is_bad_response(scores, custom_is_bad_response_config)


### PR DESCRIPTION
## What changed?

Added a module with a new `Validator` class that scores responses from RAG systems and detects & remediates bad responses.

A few notes:
- I added cleanlab_tlm as a dependency, but in the source code, I lazily import it (so either we can make the dependency optional or remove the lazy import).
- A `BadResponseConfig` (I'm open to suggestions on better names) for this module is a Pydantic BaseModel, mainly to validate that the thresholds are 0-1. I'm fine with just having this be a dictionary.
- By default, we'll add explanations to the trustworthiness score of TrustworthyRAG, but only return the trustworthiness score and the response helpfulness score (the other default scores are not used for validation at this moment). The `get_default_evaluations()` function will control what `Eval`s to use with TrustworthyRAG by default.
- TrustworthyRAG will work fine when the `tlm_api_key` is None, as long as a `TLM_API_KEY` is set as an environment variable. So a minimal constructor would look like `validator = Validator(codex_access_key="<your-access-key>")`, with the rest having pre-defined configurations as defaults.

Usage example:

```python
from cleanlab_codex import Validator

validator = Validator(codex_access_key="<your-access-key>")

CONTEXT = """Simple Water Bottle - Amber (limited edition launched Jan 1st 2025)
A water bottle designed with a perfect blend of functionality and aesthetics in mind. Crafted from high-quality, durable plastic with a sleek honey-colored finish.
Price: $24.99 \nDimensions: 10 inches height x 4 inches width"""

results = validator.validate(query="How much water can the Simple Water Bottle hold?", context=CONTEXT, response="The Simple Water Bottle can hold 34 oz of Water")
results
```

prints out:

```
{
    "is_bad_response": True,
    "alt_answer": "32oz",
    "trustworthiness": {
        "log": {
            "explanation": "The proposed response states that the Simple Water Bottle can hold 34 oz of water. However, the context information provided does not specify the capacity of the water bottle. Without explicit details about the volume it can hold, the response cannot be verified as correct. The dimensions of the bottle (10 inches height x 4 inches width) do not directly indicate its volume capacity, and the assumption made in the response could be inaccurate. A more appropriate response would acknowledge the lack of specific information regarding the bottle's capacity and suggest that the user check the product specifications for accurate details. Therefore, the proposed response is not substantiated by the provided context. \nThis response is untrustworthy due to lack of consistency in possible responses from the model. Here's one inconsistent alternate response that the model considered (which may not be accurate either): \nThe Simple Water Bottle can hold approximately 70 fluid ounces of water."
        },
        "score": 0.18455227478066594,
    },
    "response_helpfulness": {"score": 0.9975124364465637},
}

```

---

### Checklist

- [ ] _Did you link the GitHub issue?_
- [ ] _Did you follow deployment steps or bump the version if needed?_
- [x] _Did you add/update tests?_ At least for some internal functions.
- [ ] _What QA did you do?_
  - Tested...
