### PR TITLE
Added functionality for adding metadata using validate api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.12] - 2025-04-17
+
+- Support adding metadata in `validate()` method in Validator API.
+
 ## [1.0.11] - 2025-04-16
 
 - Update default thresholds for custom evals to 0.0 in `Validator` API.
@@ -59,7 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `cleanlab-codex` client library.
 
-[Unreleased]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.11...HEAD
+[Unreleased]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.12...HEAD
+[1.0.12]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.11...v1.0.12
 [1.0.11]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.10...v1.0.11
 [1.0.10]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.9...v1.0.10
 [1.0.9]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.8...v1.0.9

--- a/src/cleanlab_codex/__about__.py
+++ b/src/cleanlab_codex/__about__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: MIT
-__version__ = "1.0.11"
+__version__ = "1.0.12"

--- a/src/cleanlab_codex/internal/validator.py
+++ b/src/cleanlab_codex/internal/validator.py
@@ -65,10 +65,6 @@ def process_score_metadata(scores: ThresholdedTrustworthyRAGScore, thresholds: B
     """
     metadata: dict[str, Any] = {}
 
-    # Simple mappings for score keys to metadata keys
-    score_to_metadata_key = {
-        "query_ease": "query_ease_customized",
-    }
 
     # Simple mappings for is_bad keys
     score_to_is_bad_key = {
@@ -80,9 +76,7 @@ def process_score_metadata(scores: ThresholdedTrustworthyRAGScore, thresholds: B
 
     # Process scores and add to metadata
     for metric, score_data in scores.items():
-        # Get the appropriate metadata key, default to the original metric name
-        metadata_key = score_to_metadata_key.get(metric, metric)
-        metadata[metadata_key] = score_data["score"]
+        metadata[metric] = score_data["score"]
 
         # Add is_bad flags with standardized naming
         is_bad_key = score_to_is_bad_key.get(metric, f"is_not_{metric}")

--- a/src/cleanlab_codex/internal/validator.py
+++ b/src/cleanlab_codex/internal/validator.py
@@ -86,6 +86,9 @@ def process_score_metadata(scores: ThresholdedTrustworthyRAGScore, thresholds: B
             metadata["explanation"] = score_data["log"]["explanation"]
 
     # Add thresholds to metadata
-    metadata["thresholds"] = thresholds.model_dump()
+    thresholds_dict = thresholds.model_dump()
+    for metric in {k for k in scores if k not in thresholds_dict}:
+        thresholds_dict[metric] = thresholds.get_threshold(metric)
+    metadata["thresholds"] = thresholds_dict
 
     return metadata

--- a/src/cleanlab_codex/internal/validator.py
+++ b/src/cleanlab_codex/internal/validator.py
@@ -65,7 +65,6 @@ def process_score_metadata(scores: ThresholdedTrustworthyRAGScore, thresholds: B
     """
     metadata: dict[str, Any] = {}
 
-
     # Simple mappings for is_bad keys
     score_to_is_bad_key = {
         "trustworthiness": "is_not_trustworthy",

--- a/src/cleanlab_codex/validator.py
+++ b/src/cleanlab_codex/validator.py
@@ -4,6 +4,7 @@ Detect and remediate bad responses in RAG applications, by integrating Codex as-
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 from cleanlab_tlm import TrustworthyRAG
@@ -131,13 +132,12 @@ class Validator:
         scores, is_bad_response = self.detect(
             query=query, context=context, response=response, prompt=prompt, form_prompt=form_prompt
         )
-        final_metadata = metadata.copy() if metadata else {}
-        if log_results:
-            processed_metadata = _process_score_metadata(scores, self._bad_response_thresholds)
-            final_metadata.update(processed_metadata)
-
         expert_answer = None
         if is_bad_response:
+            final_metadata = deepcopy(metadata) if metadata else {}
+            if log_results:
+                processed_metadata = _process_score_metadata(scores, self._bad_response_thresholds)
+                final_metadata.update(processed_metadata)
             expert_answer = self._remediate(query=query, metadata=final_metadata)
 
         return {

--- a/tests/internal/test_validator.py
+++ b/tests/internal/test_validator.py
@@ -56,6 +56,7 @@ def test_process_score_metadata() -> None:
         "is_not_query_easy": False,
         "explanation": "Test explanation",
         "thresholds": {"trustworthiness": 0.7, "response_helpfulness": 0.7, "query_ease": 0.0},
+        "label": "unhelpful",
     }
 
     assert metadata == expected_metadata
@@ -66,20 +67,19 @@ def test_process_score_metadata_edge_cases() -> None:
     thresholds = BadResponseThresholds()
 
     # Test empty scores
-    metadata = process_score_metadata(cast(ThresholdedTrustworthyRAGScore, {}), thresholds)
-    assert len(metadata) == 1
-    assert "thresholds" in metadata
+    metadata_for_empty_scores = process_score_metadata(cast(ThresholdedTrustworthyRAGScore, {}), thresholds)
+    assert {"thresholds", "label"} == set(metadata_for_empty_scores.keys())
 
     # Test missing explanation
     scores = cast(ThresholdedTrustworthyRAGScore, {"trustworthiness": {"score": 0.6, "is_bad": True}})
-    metadata = process_score_metadata(scores, thresholds)
-    assert "explanation" not in metadata
+    metadata_missing_explanation = process_score_metadata(scores, thresholds)
+    assert "explanation" not in metadata_missing_explanation
 
     # Test custom metric
     scores = cast(ThresholdedTrustworthyRAGScore, {"my_metric": {"score": 0.3, "is_bad": True}})
-    metadata = process_score_metadata(scores, thresholds)
-    assert metadata["my_metric"] == 0.3
-    assert metadata["is_not_my_metric"] is True
+    metadata_custom_metric = process_score_metadata(scores, thresholds)
+    assert metadata_custom_metric["my_metric"] == 0.3
+    assert metadata_custom_metric["is_not_my_metric"] is True
 
 
 def test_update_scores_based_on_thresholds() -> None:

--- a/tests/internal/test_validator.py
+++ b/tests/internal/test_validator.py
@@ -50,7 +50,7 @@ def test_process_score_metadata() -> None:
     expected_metadata = {
         "trustworthiness": 0.8,
         "response_helpfulness": 0.6,
-        "query_ease_customized": 0.9,
+        "query_ease": 0.9,
         "is_not_trustworthy": False,
         "is_not_response_helpful": True,
         "is_not_query_easy": False,

--- a/tests/internal/test_validator.py
+++ b/tests/internal/test_validator.py
@@ -2,7 +2,12 @@ from typing import cast
 
 from cleanlab_tlm.utils.rag import TrustworthyRAGScore
 
-from cleanlab_codex.internal.validator import get_default_evaluations
+from cleanlab_codex.internal.validator import (
+    get_default_evaluations,
+    process_score_metadata,
+    update_scores_based_on_thresholds,
+)
+from cleanlab_codex.types.validator import ThresholdedTrustworthyRAGScore
 from cleanlab_codex.validator import BadResponseThresholds
 
 
@@ -27,3 +32,79 @@ def make_is_bad_response_config(trustworthiness: float, response_helpfulness: fl
 
 def test_get_default_evaluations() -> None:
     assert {evaluation.name for evaluation in get_default_evaluations()} == {"response_helpfulness"}
+
+
+def test_process_score_metadata() -> None:
+    # Create test scores with various metrics
+    thresholded_scores = {
+        "trustworthiness": {"score": 0.8, "is_bad": False, "log": {"explanation": "Test explanation"}},
+        "response_helpfulness": {"score": 0.6, "is_bad": True},
+        "query_ease": {"score": 0.9, "is_bad": False},
+    }
+
+    thresholds = BadResponseThresholds(trustworthiness=0.7, response_helpfulness=0.7)
+
+    metadata = process_score_metadata(cast(ThresholdedTrustworthyRAGScore, thresholded_scores), thresholds)
+
+    # Check scores and flags
+    expected_metadata = {
+        "trustworthiness": 0.8,
+        "response_helpfulness": 0.6,
+        "query_ease_customized": 0.9,
+        "is_not_trustworthy": False,
+        "is_not_response_helpful": True,
+        "is_not_query_easy": False,
+        "explanation": "Test explanation",
+        "thresholds": {"trustworthiness": 0.7, "response_helpfulness": 0.7},
+    }
+
+    assert metadata == expected_metadata
+
+
+def test_process_score_metadata_edge_cases() -> None:
+    """Test edge cases for process_score_metadata."""
+    thresholds = BadResponseThresholds()
+
+    # Test empty scores
+    metadata = process_score_metadata(cast(ThresholdedTrustworthyRAGScore, {}), thresholds)
+    assert len(metadata) == 1
+    assert "thresholds" in metadata
+
+    # Test missing explanation
+    scores = cast(ThresholdedTrustworthyRAGScore, {"trustworthiness": {"score": 0.6, "is_bad": True}})
+    metadata = process_score_metadata(scores, thresholds)
+    assert "explanation" not in metadata
+
+    # Test custom metric
+    scores = cast(ThresholdedTrustworthyRAGScore, {"my_metric": {"score": 0.3, "is_bad": True}})
+    metadata = process_score_metadata(scores, thresholds)
+    assert metadata["my_metric"] == 0.3
+    assert metadata["is_not_my_metric"] is True
+
+
+def test_update_scores_based_on_thresholds() -> None:
+    """Test that update_scores_based_on_thresholds correctly flags scores based on thresholds."""
+    raw_scores = cast(
+        TrustworthyRAGScore,
+        {
+            "trustworthiness": {"score": 0.6},  # Below threshold
+            "response_helpfulness": {"score": 0.8},  # Above threshold
+            "custom_metric": {"score": 0.4},  # Below custom threshold
+            "another_metric": {"score": 0.6},  # Uses default threshold
+        },
+    )
+
+    thresholds = BadResponseThresholds(trustworthiness=0.7, response_helpfulness=0.7, custom_metric=0.45)  # type: ignore[call-arg]
+
+    scores = update_scores_based_on_thresholds(raw_scores, thresholds)
+
+    expected_is_bad = {
+        "trustworthiness": True,
+        "response_helpfulness": False,
+        "custom_metric": True,
+        "another_metric": False,
+    }
+
+    for metric, expected in expected_is_bad.items():
+        assert scores[metric]["is_bad"] is expected
+    assert all(scores[k]["score"] == raw_scores[k]["score"] for k in raw_scores)

--- a/tests/internal/test_validator.py
+++ b/tests/internal/test_validator.py
@@ -55,7 +55,7 @@ def test_process_score_metadata() -> None:
         "is_not_response_helpful": True,
         "is_not_query_easy": False,
         "explanation": "Test explanation",
-        "thresholds": {"trustworthiness": 0.7, "response_helpfulness": 0.7},
+        "thresholds": {"trustworthiness": 0.7, "response_helpfulness": 0.7, "query_ease": 0.0},
     }
 
     assert metadata == expected_metadata

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -133,8 +133,8 @@ class TestValidator:
         mock_project.from_access_key.return_value.query.return_value = ("expert answer", None)
 
         validator = Validator(codex_access_key="test")
-        result = validator._remediate("test query")  # noqa: SLF001
+        result = validator._remediate(query="test query")  # noqa: SLF001
 
         # Verify project.query was called
-        mock_project.from_access_key.return_value.query.assert_called_once_with(question="test query")
+        mock_project.from_access_key.return_value.query.assert_called_once_with(question="test query", metadata=None)
         assert result == "expert answer"


### PR DESCRIPTION
<!-- TODO: Delete anything from this template that doesn't apply -->

## Key Info

- Implementation plan: [link](https://www.notion.so/cleanlab/Validator-Metadata-Support-1d5c7fee85be80f9aa6afaa7079a0c2f)
- Priority: urgent

## What changed?

Two new arguments added to `validate()` in the Valdiator API
- `metadata: dict` for user provided metadata
- `log_results: bool` for including internally computed metadata, such as scores from TrustwortyRAG

