### PR TITLE
Refactor threshold validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.9] - 2025-04-10
+
 - Refactor threshold validation in the `Validator` class to only check user-provided metrics.
 
 ## [1.0.8] - 2025-04-03
@@ -49,7 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `cleanlab-codex` client library.
 
-[Unreleased]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.8...HEAD
+[Unreleased]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.9...HEAD
+[1.0.9]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.8...v1.0.9
 [1.0.8]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.7...v1.0.8
 [1.0.7]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.6...v1.0.7
 [1.0.6]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.5...v1.0.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Refactor threshold validation in the `Validator` class to only check user-provided metrics.
+
 ## [1.0.8] - 2025-04-03
 
 - Update `Project.query()` method with optional `metadata` property to log and store arbitrary metadata.

--- a/src/cleanlab_codex/__about__.py
+++ b/src/cleanlab_codex/__about__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: MIT
-__version__ = "1.0.8"
+__version__ = "1.0.9"

--- a/src/cleanlab_codex/validator.py
+++ b/src/cleanlab_codex/validator.py
@@ -56,9 +56,9 @@ class Validator:
                 a response is bad or not. Each key corresponds to an Eval from [TrustworthyRAG](/tlm/api/python/utils.rag/#class-trustworthyrag),
                 and the value indicates a threshold (between 0 and 1) below which Eval scores are treated as detected issues. A response
                 is flagged as bad if any issues are detected. If not provided or only partially provided, default thresholds will be used
-                for any missing metrics. Note that if a threshold is provided for a metric, that metric must correspond to an eval 
-                that is configured to run (with the exception of 'trustworthiness' which is always implicitly configured). You can 
-                configure arbitrary evals to run, and their thresholds will use default values unless explicitly set. See 
+                for any missing metrics. Note that if a threshold is provided for a metric, that metric must correspond to an eval
+                that is configured to run (with the exception of 'trustworthiness' which is always implicitly configured). You can
+                configure arbitrary evals to run, and their thresholds will use default values unless explicitly set. See
                 [`BadResponseThresholds`](/codex/api/python/validator/#class-badresponsethresholds) for more details on the default values.
 
         Raises:
@@ -90,7 +90,10 @@ class Validator:
             # Check if there are any user-provided thresholds without corresponding evals
             _extra_thresholds = set(_threshold_keys) - set(_evals)
             if _extra_thresholds:
-                error_msg = f"Found thresholds for non-existent evaluation metrics: {_extra_thresholds}"
+                error_msg = (
+                    f"Found thresholds for metrics that are not available: {_extra_thresholds}. "
+                    "Available metrics are determined by configured evals plus 'trustworthiness' which is always included."
+                )
                 raise ValueError(error_msg)
 
     def validate(

--- a/src/cleanlab_codex/validator.py
+++ b/src/cleanlab_codex/validator.py
@@ -55,12 +55,14 @@ class Validator:
             bad_response_thresholds (dict[str, float], optional): Detection score thresholds used to flag whether
                 a response is bad or not. Each key corresponds to an Eval from [TrustworthyRAG](/tlm/api/python/utils.rag/#class-trustworthyrag),
                 and the value indicates a threshold (between 0 and 1) below which Eval scores are treated as detected issues. A response
-                is flagged as bad if any issues are detected. If not provided, default thresholds will be used. See
-                [`BadResponseThresholds`](/codex/api/python/validator/#class-badresponsethresholds) for more details.
+                is flagged as bad if any issues are detected. If not provided or only partially provided, default thresholds will be used
+                for any missing metrics - for example, if only 'trustworthiness' is specified, 'response_helpfulness' will use its default
+                threshold. See [`BadResponseThresholds`](/codex/api/python/validator/#class-badresponsethresholds) for more details on the
+                default values and more details.
 
         Raises:
             ValueError: If both tlm_api_key and api_key in trustworthy_rag_config are provided.
-            ValueError: If bad_response_thresholds contains thresholds for non-existent evaluation metrics.
+            ValueError: If bad_response_thresholds contains thresholds for evaluation metrics that are not included in the TrustworthyRAG evals configuration.
             TypeError: If any threshold value is not a number.
             ValueError: If any threshold value is not between 0 and 1.
         """

--- a/src/cleanlab_codex/validator.py
+++ b/src/cleanlab_codex/validator.py
@@ -92,7 +92,7 @@ class Validator:
             if _extra_thresholds:
                 error_msg = (
                     f"Found thresholds for metrics that are not available: {_extra_thresholds}. "
-                    "Available metrics are determined by configured evals plus 'trustworthiness' which is always included."
+                    "Available metrics are determined by the evals parameter provided to TrustworthyRAG plus 'trustworthiness' which is always included."
                 )
                 raise ValueError(error_msg)
 

--- a/src/cleanlab_codex/validator.py
+++ b/src/cleanlab_codex/validator.py
@@ -81,13 +81,14 @@ class Validator:
 
         self._bad_response_thresholds = BadResponseThresholds.model_validate(bad_response_thresholds or {})
 
-        _threshold_keys = self._bad_response_thresholds.model_dump().keys()
-
-        # Check if there are any thresholds without corresponding evals (this is an error)
-        _extra_thresholds = set(_threshold_keys) - set(_evals)
-        if _extra_thresholds:
-            error_msg = f"Found thresholds for non-existent evaluation metrics: {_extra_thresholds}"
-            raise ValueError(error_msg)
+        # Only check thresholds that were explicitly provided by the user
+        if bad_response_thresholds is not None:
+            _threshold_keys = bad_response_thresholds.keys()
+            # Check if there are any user-provided thresholds without corresponding evals
+            _extra_thresholds = set(_threshold_keys) - set(_evals)
+            if _extra_thresholds:
+                error_msg = f"Found thresholds for non-existent evaluation metrics: {_extra_thresholds}"
+                raise ValueError(error_msg)
 
     def validate(
         self,

--- a/src/cleanlab_codex/validator.py
+++ b/src/cleanlab_codex/validator.py
@@ -56,13 +56,14 @@ class Validator:
                 a response is bad or not. Each key corresponds to an Eval from [TrustworthyRAG](/tlm/api/python/utils.rag/#class-trustworthyrag),
                 and the value indicates a threshold (between 0 and 1) below which Eval scores are treated as detected issues. A response
                 is flagged as bad if any issues are detected. If not provided or only partially provided, default thresholds will be used
-                for any missing metrics - for example, if only 'trustworthiness' is specified, 'response_helpfulness' will use its default
-                threshold. See [`BadResponseThresholds`](/codex/api/python/validator/#class-badresponsethresholds) for more details on the
-                default values and more details.
+                for any missing metrics. Note that if a threshold is provided for a metric, that metric must correspond to an eval 
+                that is configured to run (with the exception of 'trustworthiness' which is always implicitly configured). You can 
+                configure arbitrary evals to run, and their thresholds will use default values unless explicitly set. See 
+                [`BadResponseThresholds`](/codex/api/python/validator/#class-badresponsethresholds) for more details on the default values.
 
         Raises:
             ValueError: If both tlm_api_key and api_key in trustworthy_rag_config are provided.
-            ValueError: If bad_response_thresholds contains thresholds for evaluation metrics that are not included in the TrustworthyRAG evals configuration.
+            ValueError: If any user-provided thresholds in bad_response_thresholds are for evaluation metrics that are not available in the current evaluation setup (except 'trustworthiness' which is always available).
             TypeError: If any threshold value is not a number.
             ValueError: If any threshold value is not between 0 and 1.
         """

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -150,7 +150,7 @@ class TestValidator:
         assert_threshold_equal(validator, "response_helpfulness", 0.7)
 
         # Test with extra thresholds that should raise ValueError
-        with pytest.raises(ValueError, match="Found thresholds for non-existent evaluation metrics"):
+        with pytest.raises(ValueError, match="Found thresholds for metrics that are not available"):
             Validator(codex_access_key="test", bad_response_thresholds={"non_existent_metric": 0.5})
 
     def test_default_thresholds(self, mock_project: Mock, mock_trustworthy_rag: Mock) -> None:  # noqa: ARG002
@@ -176,7 +176,7 @@ class TestValidator:
         assert_threshold_equal(validator, "response_helpfulness", 0.7)  # Default should apply
 
         # Test with non-existent evals in trustworthy_rag_config
-        with pytest.raises(ValueError, match="Found thresholds for non-existent evaluation metrics"):
+        with pytest.raises(ValueError, match="Found thresholds for metrics that are not available"):
             Validator(codex_access_key="test", bad_response_thresholds={"non_existent_eval": 0.5})
 
 
@@ -187,7 +187,8 @@ def test_validator_with_empty_evals(mock_project: Mock) -> None:  # noqa: ARG001
 
         # Attempt to create a Validator with an invalid threshold
         with pytest.raises(
-            ValueError, match="Found thresholds for non-existent evaluation metrics: {'response_helpfulness'}"
+            ValueError,
+            match="Found thresholds for metrics that are not available: {'response_helpfulness'}. Available metrics are determined by configured evals plus 'trustworthiness' which is always included.",
         ):
             Validator(
                 codex_access_key="test",

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -188,7 +188,7 @@ def test_validator_with_empty_evals(mock_project: Mock) -> None:  # noqa: ARG001
         # Attempt to create a Validator with an invalid threshold
         with pytest.raises(
             ValueError,
-            match="Found thresholds for metrics that are not available: {'response_helpfulness'}. Available metrics are determined by configured evals plus 'trustworthiness' which is always included.",
+            match="Found thresholds for metrics that are not available: {'response_helpfulness'}. Available metrics are determined by the evals parameter provided to TrustworthyRAG plus 'trustworthiness' which is always included.",
         ):
             Validator(
                 codex_access_key="test",


### PR DESCRIPTION
## What changed?

Refining the threshold validation logic in the constructor of `Validator` to just run for user-provided thresholds.