### PR TITLE
add async version of validate method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.10] - 2025-04-15
+
+- Add async support to `Validator` API.
+
 ## [1.0.9] - 2025-04-10
 
 - Refactor threshold validation in the `Validator` class to only check user-provided metrics.
@@ -51,7 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `cleanlab-codex` client library.
 
-[Unreleased]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.9...HEAD
+[Unreleased]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.10...HEAD
+[1.0.10]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.9...v1.0.10
 [1.0.9]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.8...v1.0.9
 [1.0.8]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.7...v1.0.8
 [1.0.7]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.6...v1.0.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "cleanlab-tlm~=1.0.12",
+  "cleanlab-tlm~=1.0.18",
   "codex-sdk==0.1.0-alpha.14",
   "pydantic>=2.0.0, <3",
 ]

--- a/src/cleanlab_codex/__about__.py
+++ b/src/cleanlab_codex/__about__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: MIT
-__version__ = "1.0.9"
+__version__ = "1.0.10"


### PR DESCRIPTION
## What changed?

Adds an async version of validate method for Validator class. This is needed for integrating Codex as Backup into Agility. Otherwise we get an error that the event loop is already running when calling self._event_loop.run_until_complete() in `TrustworthyRAG.score()`. Note: depends on https://github.com/cleanlab/cleanlab-tlm/pull/47 being merged first.

## What do you want the reviewer(s) to focus on?

---

### Checklist

- [ ] _Did you link the GitHub issue?_
- [ ] _Did you follow deployment steps or bump the version if needed?_
- [ ] _Did you add/update tests?_
- [ ] _What QA did you do?_
  - Tested...
