### PR TITLE
refactor validator to wrap Codex API

### DIFF
--- a/src/cleanlab_codex/project.py
+++ b/src/cleanlab_codex/project.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import TYPE_CHECKING as _TYPE_CHECKING
-from typing import Any, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from codex import AuthenticationError
 
@@ -17,6 +17,9 @@ if _TYPE_CHECKING:
     from datetime import datetime
 
     from codex import Codex as _Codex
+    from codex.types.project_validate_params import BadResponseThresholds
+    from codex.types.project_validate_params import Options as ProjectValidateOptions
+    from codex.types.project_validate_response import ProjectValidateResponse
 
     from cleanlab_codex.types.entry import EntryCreate
 
@@ -222,5 +225,30 @@ class Project:
 
         return fallback_answer, entry
 
-    def increment_queries(self) -> None:
-        self._sdk_client.projects.increment_queries(self._id)
+    def validate(
+        self,
+        context: str,
+        prompt: str,
+        query: str,
+        response: str,
+        *,
+        bad_response_thresholds: Optional[BadResponseThresholds] = None,
+        constrain_outputs: Optional[List[str]] = None,
+        custom_metadata: Optional[object] = None,
+        eval_scores: Optional[Dict[str, float]] = None,
+        options: Optional[ProjectValidateOptions] = None,
+        quality_preset: Literal["best", "high", "medium", "low", "base"] = "medium",
+    ) -> ProjectValidateResponse:
+        return self._sdk_client.projects.validate(
+            self._id,
+            context=context,
+            prompt=prompt,
+            query=query,
+            response=response,
+            bad_response_thresholds=bad_response_thresholds,
+            constrain_outputs=constrain_outputs,
+            custom_metadata=custom_metadata,
+            eval_scores=eval_scores,
+            options=options,
+            quality_preset=quality_preset,
+        )

--- a/src/cleanlab_codex/project.py
+++ b/src/cleanlab_codex/project.py
@@ -232,7 +232,7 @@ class Project:
         query: str,
         response: str,
         *,
-        bad_response_thresholds: Optional[BadResponseThresholds] = None,
+        bad_response_thresholds: BadResponseThresholds = {},
         constrain_outputs: Optional[List[str]] = None,
         custom_metadata: Optional[object] = None,
         eval_scores: Optional[Dict[str, float]] = None,

--- a/src/cleanlab_codex/validator.py
+++ b/src/cleanlab_codex/validator.py
@@ -4,59 +4,32 @@ Detect and remediate bad responses in RAG applications, by integrating Codex as-
 
 from __future__ import annotations
 
-from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Callable, Optional, cast
+from typing import Any, Callable, Optional, cast
 
 from cleanlab_tlm import TrustworthyRAG
 from pydantic import BaseModel, Field, field_validator
 
-from cleanlab_codex.internal.validator import (
-    get_default_evaluations,
-    get_default_trustworthyrag_config,
-)
-from cleanlab_codex.internal.validator import (
-    process_score_metadata as _process_score_metadata,
-)
-from cleanlab_codex.internal.validator import (
-    update_scores_based_on_thresholds as _update_scores_based_on_thresholds,
-)
 from cleanlab_codex.project import Project
-
-if TYPE_CHECKING:
-    from cleanlab_codex.types.validator import ThresholdedTrustworthyRAGScore
 
 
 class Validator:
     def __init__(
         self,
         codex_access_key: str,
-        tlm_api_key: Optional[str] = None,
-        trustworthy_rag_config: Optional[dict[str, Any]] = None,
         bad_response_thresholds: Optional[dict[str, float]] = None,
     ):
         """Real-time detection and remediation of bad responses in RAG applications, powered by Cleanlab's TrustworthyRAG and Codex.
 
         This object combines Cleanlab's TrustworthyRAG evaluation scores with configurable thresholds to detect potentially bad responses
-        in your RAG application. When a bad response is detected, this Validator automatically attempts to remediate by retrieving an expert-provided
+        in your RAG application. When a bad response is detected, Cleanlab automatically attempts to remediate by retrieving an expert-provided
         answer from the Codex Project you've integrated with your RAG app. If no expert answer is available,
         the corresponding query is logged in the Codex Project for SMEs to answer.
 
         For production, use the `validate()` method which provides a complete validation workflow including both detection and remediation.
-        A `detect()` method is separately available for you to test/tune detection configurations like score thresholds and TrustworthyRAG settings
-        without triggering any Codex lookups that otherwise could affect the state of the corresponding Codex Project.
 
         Args:
             codex_access_key (str): The [access key](/codex/web_tutorials/create_project/#access-keys) for a Codex project. Used to retrieve expert-provided answers
                 when bad responses are detected, or otherwise log the corresponding queries for SMEs to answer.
-
-            tlm_api_key (str, optional): API key for accessing [TrustworthyRAG](/tlm/api/python/utils.rag/#class-trustworthyrag). If not provided, this must be specified
-                in `trustworthy_rag_config`.
-
-            trustworthy_rag_config (dict[str, Any], optional): Optional initialization arguments for [TrustworthyRAG](/tlm/api/python/utils.rag/#class-trustworthyrag),
-                which is used to detect response issues. If not provided, a default configuration will be used.
-                By default, this Validator uses the same default configurations as [TrustworthyRAG](/tlm/api/python/utils.rag/#class-trustworthyrag), except:
-                - Explanations are returned in logs for better debugging
-                - Only the `response_helpfulness` eval is run
 
             bad_response_thresholds (dict[str, float], optional): Detection score thresholds used to flag whether
                 a response is bad or not. Each key corresponds to an Eval from [TrustworthyRAG](/tlm/api/python/utils.rag/#class-trustworthyrag),
@@ -68,39 +41,13 @@ class Validator:
                 [`BadResponseThresholds`](/codex/api/python/validator/#class-badresponsethresholds) for more details on the default values.
 
         Raises:
-            ValueError: If both tlm_api_key and api_key in trustworthy_rag_config are provided.
-            ValueError: If any user-provided thresholds in bad_response_thresholds are for evaluation metrics that are not available in the current evaluation setup (except 'trustworthiness' which is always available).
             TypeError: If any threshold value is not a number.
             ValueError: If any threshold value is not between 0 and 1.
         """
-        trustworthy_rag_config = trustworthy_rag_config or get_default_trustworthyrag_config()
-        if tlm_api_key is not None and "api_key" in trustworthy_rag_config:
-            error_msg = "Cannot specify both tlm_api_key and api_key in trustworthy_rag_config"
-            raise ValueError(error_msg)
-        if tlm_api_key is not None:
-            trustworthy_rag_config["api_key"] = tlm_api_key
-
         self._project: Project = Project.from_access_key(access_key=codex_access_key)
-
-        trustworthy_rag_config.setdefault("evals", get_default_evaluations())
-        self._tlm_rag = TrustworthyRAG(**trustworthy_rag_config)
-
-        # Validate that all the necessary thresholds are present in the TrustworthyRAG.
-        _evals = [e.name for e in self._tlm_rag.get_evals()] + ["trustworthiness"]
-
-        self._bad_response_thresholds = BadResponseThresholds.model_validate(bad_response_thresholds or {})
-
-        # Only check thresholds that were explicitly provided by the user
-        if bad_response_thresholds is not None:
-            _threshold_keys = bad_response_thresholds.keys()
-            # Check if there are any user-provided thresholds without corresponding evals
-            _extra_thresholds = set(_threshold_keys) - set(_evals)
-            if _extra_thresholds:
-                error_msg = (
-                    f"Found thresholds for metrics that are not available: {_extra_thresholds}. "
-                    "Available metrics are determined by the evals parameter provided to TrustworthyRAG plus 'trustworthiness' which is always included."
-                )
-                raise ValueError(error_msg)
+        self._bad_response_thresholds = (
+            BadResponseThresholds.model_validate(bad_response_thresholds) if bad_response_thresholds else None
+        )
 
     def validate(
         self,
@@ -111,7 +58,6 @@ class Validator:
         prompt: Optional[str] = None,
         form_prompt: Optional[Callable[[str, str], str]] = None,
         metadata: Optional[dict[str, Any]] = None,
-        log_results: bool = True,
     ) -> dict[str, Any]:
         """Evaluate whether the AI-generated response is bad, and if so, request an alternate expert answer.
         If no expert answer is available, this query is still logged for SMEs to answer.
@@ -129,172 +75,33 @@ class Validator:
                 - 'is_bad_response': True if the response is flagged as potentially bad, False otherwise. When True, a Codex lookup is performed, which logs this query into the Codex Project for SMEs to answer.
                 - Additional keys from a [`ThresholdedTrustworthyRAGScore`](/codex/api/python/types.validator/#class-thresholdedtrustworthyragscore) dictionary: each corresponds to a [TrustworthyRAG](/tlm/api/python/utils.rag/#class-trustworthyrag) evaluation metric, and points to the score for this evaluation as well as a boolean `is_bad` flagging whether the score falls below the corresponding threshold.
         """
-        scores, is_bad_response = self.detect(
-            query=query, context=context, response=response, prompt=prompt, form_prompt=form_prompt
-        )
-        expert_answer = None
-        if is_bad_response:
-            final_metadata = deepcopy(metadata) if metadata else {}
-            if log_results:
-                processed_metadata = _process_score_metadata(scores, self._bad_response_thresholds)
-                final_metadata.update(processed_metadata)
-            expert_answer = self._remediate(query=query, metadata=final_metadata)
+        if not prompt and not form_prompt:
+            form_prompt = TrustworthyRAG._default_prompt_formatter  # noqa: SLF001
 
-        self._project.increment_queries()
+        prompt = prompt or form_prompt(query, context)
 
-        return {
-            "expert_answer": expert_answer,
-            "is_bad_response": is_bad_response,
-            **scores,
-        }
-
-    async def validate_async(
-        self,
-        *,
-        query: str,
-        context: str,
-        response: str,
-        prompt: Optional[str] = None,
-        form_prompt: Optional[Callable[[str, str], str]] = None,
-        metadata: Optional[dict[str, Any]] = None,
-        log_results: bool = True,
-    ) -> dict[str, Any]:
-        """Evaluate whether the AI-generated response is bad, and if so, request an alternate expert answer.
-        If no expert answer is available, this query is still logged for SMEs to answer.
-
-        Args:
-            query (str): The user query that was used to generate the response.
-            context (str): The context that was retrieved from the RAG Knowledge Base and used to generate the response.
-            response (str): A reponse from your LLM/RAG system.
-            prompt (str, optional): Optional prompt representing the actual inputs (combining query, context, and system instructions into one string) to the LLM that generated the response.
-            form_prompt (Callable[[str, str], str], optional): Optional function to format the prompt based on query and context. Cannot be provided together with prompt, provide one or the other. This function should take query and context as parameters and return a formatted prompt string. If not provided, a default prompt formatter will be used. To include a system prompt or any other special instructions for your LLM, incorporate them directly in your custom form_prompt() function definition.
-
-        Returns:
-            dict[str, Any]: A dictionary containing:
-                - 'expert_answer': Alternate SME-provided answer from Codex if the response was flagged as bad and an answer was found in the Codex Project, or None otherwise.
-                - 'is_bad_response': True if the response is flagged as potentially bad, False otherwise. When True, a Codex lookup is performed, which logs this query into the Codex Project for SMEs to answer.
-                - Additional keys from a [`ThresholdedTrustworthyRAGScore`](/codex/api/python/types.validator/#class-thresholdedtrustworthyragscore) dictionary: each corresponds to a [TrustworthyRAG](/tlm/api/python/utils.rag/#class-trustworthyrag) evaluation metric, and points to the score for this evaluation as well as a boolean `is_bad` flagging whether the score falls below the corresponding threshold.
-        """
-        scores, is_bad_response = await self.detect_async(query, context, response, prompt, form_prompt)
-        final_metadata = metadata.copy() if metadata else {}
-        if log_results:
-            processed_metadata = _process_score_metadata(scores, self._bad_response_thresholds)
-            final_metadata.update(processed_metadata)
-
-        expert_answer = None
-        if is_bad_response:
-            expert_answer = self._remediate(query=query, metadata=final_metadata)
-
-        self._project.increment_queries()
-
-        return {
-            "expert_answer": expert_answer,
-            "is_bad_response": is_bad_response,
-            **scores,
-        }
-
-    def detect(
-        self,
-        *,
-        query: str,
-        context: str,
-        response: str,
-        prompt: Optional[str] = None,
-        form_prompt: Optional[Callable[[str, str], str]] = None,
-    ) -> tuple[ThresholdedTrustworthyRAGScore, bool]:
-        """Score response quality using TrustworthyRAG and flag bad responses based on configured thresholds.
-
-        Note:
-            Use this method instead of `validate()` to test/tune detection configurations like score thresholds and TrustworthyRAG settings.
-            This `detect()` method will not affect your Codex Project, whereas `validate()` will log queries whose response was detected as bad into the Codex Project and is thus only suitable for production, not testing.
-            Both this method and `validate()` rely on this same detection logic, so you can use this method to first optimize detections and then switch to using `validate()`.
-
-        Args:
-            query (str): The user query that was used to generate the response.
-            context (str): The context that was retrieved from the RAG Knowledge Base and used to generate the response.
-            response (str): A reponse from your LLM/RAG system.
-            prompt (str, optional): Optional prompt representing the actual inputs (combining query, context, and system instructions into one string) to the LLM that generated the response.
-            form_prompt (Callable[[str, str], str], optional): Optional function to format the prompt based on query and context. Cannot be provided together with prompt, provide one or the other. This function should take query and context as parameters and return a formatted prompt string. If not provided, a default prompt formatter will be used. To include a system prompt or any other special instructions for your LLM, incorporate them directly in your custom form_prompt() function definition.
-
-        Returns:
-            tuple[ThresholdedTrustworthyRAGScore, bool]: A tuple containing:
-                - ThresholdedTrustworthyRAGScore: Quality scores for different evaluation metrics like trustworthiness
-                  and response helpfulness. Each metric has a score between 0-1. It also has a boolean flag, `is_bad` indicating whether the score is below a given threshold.
-                - bool: True if the response is determined to be bad based on the evaluation scores
-                  and configured thresholds, False otherwise.
-        """
-        scores = self._tlm_rag.score(
-            response=response,
-            query=query,
+        result = self._project.validate(
             context=context,
             prompt=prompt,
-            form_prompt=form_prompt,
-        )
-
-        thresholded_scores = _update_scores_based_on_thresholds(
-            scores=scores,
-            thresholds=self._bad_response_thresholds,
-        )
-
-        is_bad_response = any(score_dict["is_bad"] for score_dict in thresholded_scores.values())
-        return thresholded_scores, is_bad_response
-
-    async def detect_async(
-        self,
-        query: str,
-        context: str,
-        response: str,
-        prompt: Optional[str] = None,
-        form_prompt: Optional[Callable[[str, str], str]] = None,
-    ) -> tuple[ThresholdedTrustworthyRAGScore, bool]:
-        """Score response quality using TrustworthyRAG and flag bad responses based on configured thresholds.
-
-        Note:
-            Use this method instead of `validate()` to test/tune detection configurations like score thresholds and TrustworthyRAG settings.
-            This `detect()` method will not affect your Codex Project, whereas `validate()` will log queries whose response was detected as bad into the Codex Project and is thus only suitable for production, not testing.
-            Both this method and `validate()` rely on this same detection logic, so you can use this method to first optimize detections and then switch to using `validate()`.
-
-        Args:
-            query (str): The user query that was used to generate the response.
-            context (str): The context that was retrieved from the RAG Knowledge Base and used to generate the response.
-            response (str): A reponse from your LLM/RAG system.
-            prompt (str, optional): Optional prompt representing the actual inputs (combining query, context, and system instructions into one string) to the LLM that generated the response.
-            form_prompt (Callable[[str, str], str], optional): Optional function to format the prompt based on query and context. Cannot be provided together with prompt, provide one or the other. This function should take query and context as parameters and return a formatted prompt string. If not provided, a default prompt formatter will be used. To include a system prompt or any other special instructions for your LLM, incorporate them directly in your custom form_prompt() function definition.
-
-        Returns:
-            tuple[ThresholdedTrustworthyRAGScore, bool]: A tuple containing:
-                - ThresholdedTrustworthyRAGScore: Quality scores for different evaluation metrics like trustworthiness
-                  and response helpfulness. Each metric has a score between 0-1. It also has a boolean flag, `is_bad` indicating whether the score is below a given threshold.
-                - bool: True if the response is determined to be bad based on the evaluation scores
-                  and configured thresholds, False otherwise.
-        """
-        scores = await self._tlm_rag.score_async(
-            response=response,
             query=query,
-            context=context,
-            prompt=prompt,
-            form_prompt=form_prompt,
+            response=response,
+            bad_response_thresholds=self._bad_response_thresholds,
+            custom_metadata=metadata,
         )
 
-        thresholded_scores = _update_scores_based_on_thresholds(
-            scores=scores,
-            thresholds=self._bad_response_thresholds,
-        )
+        formatted_eval_scores = {
+            eval_name: {
+                "score": eval_scores.score,
+                "is_bad": eval_scores.is_bad,
+            }
+            for eval_name, eval_scores in result.eval_scores.items()
+        }
 
-        is_bad_response = any(score_dict["is_bad"] for score_dict in thresholded_scores.values())
-        return thresholded_scores, is_bad_response
-
-    def _remediate(self, *, query: str, metadata: dict[str, Any] | None = None) -> str | None:
-        """Request a SME-provided answer for this query, if one is available in Codex.
-
-        Args:
-            query (str): The user's original query to get SME-provided answer for.
-
-        Returns:
-            str | None: The SME-provided answer from Codex, or None if no answer could be found in the Codex Project.
-        """
-        codex_answer, _ = self._project.query(question=query, metadata=metadata)
-        return codex_answer
+        return {
+            "expert_answer": result.expert_answer,
+            "is_bad_response": result.is_bad_response,
+            **formatted_eval_scores,
+        }
 
 
 class BadResponseThresholds(BaseModel):

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -2,6 +2,7 @@ from typing import Generator
 from unittest.mock import Mock, patch
 
 import pytest
+from codex.types.project_validate_response import EvalScores, ProjectValidateResponse
 from pydantic import ValidationError
 
 from cleanlab_codex.validator import BadResponseThresholds, Validator
@@ -45,7 +46,16 @@ class TestBadResponseThresholds:
 @pytest.fixture
 def mock_project() -> Generator[Mock, None, None]:
     with patch("cleanlab_codex.validator.Project") as mock:
-        mock.from_access_key.return_value = Mock()
+        mock_obj = Mock()
+        mock_obj.validate.return_value = ProjectValidateResponse(
+            is_bad_response=True,
+            expert_answer=None,
+            eval_scores={
+                "response_helpfulness": EvalScores(score=0.95, is_bad=False),
+                "trustworthiness": EvalScores(score=0.5, is_bad=True),
+            },
+        )
+        mock.from_access_key.return_value = mock_obj
         yield mock
 
 
@@ -69,38 +79,19 @@ def assert_threshold_equal(validator: Validator, eval_name: str, threshold: floa
 
 
 class TestValidator:
-    def test_init(self, mock_project: Mock, mock_trustworthy_rag: Mock) -> None:
+    def test_init(self, mock_project: Mock) -> None:
         Validator(codex_access_key="test")
 
         # Verify Project was initialized with access key
         mock_project.from_access_key.assert_called_once_with(access_key="test")
 
-        # Verify TrustworthyRAG was initialized with default config
-        mock_trustworthy_rag.assert_called_once()
-
-    def test_init_with_tlm_api_key(self, mock_project: Mock, mock_trustworthy_rag: Mock) -> None:  # noqa: ARG002
-        Validator(codex_access_key="test", tlm_api_key="tlm-key")
-
-        # Verify TrustworthyRAG was initialized with API key
-        config = mock_trustworthy_rag.call_args[1]
-        assert config["api_key"] == "tlm-key"
-
-    def test_init_with_config_conflict(self, mock_project: Mock, mock_trustworthy_rag: Mock) -> None:  # noqa: ARG002
-        with pytest.raises(ValueError, match="Cannot specify both tlm_api_key and api_key in trustworthy_rag_config"):
-            Validator(codex_access_key="test", tlm_api_key="tlm-key", trustworthy_rag_config={"api_key": "config-key"})
-
-    def test_validate(self, mock_project: Mock, mock_trustworthy_rag: Mock) -> None:  # noqa: ARG002
+    def test_validate(self, mock_project: Mock) -> None:  # noqa: ARG002
         validator = Validator(codex_access_key="test")
 
         result = validator.validate(query="test query", context="test context", response="test response")
 
-        # Verify TrustworthyRAG.score was called
-        mock_trustworthy_rag.return_value.score.assert_called_once_with(
-            response="test response", query="test query", context="test context", prompt=None, form_prompt=None
-        )
-
         # Verify expected result structure
-        assert result["is_bad_response"] is False
+        assert result["is_bad_response"] is True
         assert result["expert_answer"] is None
 
         eval_metrics = ["trustworthiness", "response_helpfulness"]
@@ -110,38 +101,25 @@ class TestValidator:
             assert "is_bad" in result[metric]
 
     def test_validate_expert_answer(self, mock_project: Mock, mock_trustworthy_rag: Mock) -> None:  # noqa: ARG002
-        # Setup mock project query response
-        mock_project.from_access_key.return_value.query.return_value = ("expert answer", None)
-
-        # Basically any response will be flagged as untrustworthy
         validator = Validator(codex_access_key="test", bad_response_thresholds={"trustworthiness": 1.0})
-        result = validator.validate(query="test query", context="test context", response="test response")
-        assert result["expert_answer"] == "expert answer"
 
         mock_project.from_access_key.return_value.query.return_value = (None, None)
         result = validator.validate(query="test query", context="test context", response="test response")
         assert result["expert_answer"] is None
 
-    def test_detect(self, mock_project: Mock, mock_trustworthy_rag: Mock) -> None:  # noqa: ARG002
-        validator = Validator(codex_access_key="test")
-
-        scores, is_bad = validator.detect(query="test query", context="test context", response="test response")
-
-        # Verify scores match mock return value
-        assert scores["trustworthiness"]["score"] == 0.8
-        assert scores["response_helpfulness"]["score"] == 0.7
-        assert not is_bad  # Since mock scores are above default thresholds
-
-    def test_remediate(self, mock_project: Mock, mock_trustworthy_rag: Mock) -> None:  # noqa: ARG002
         # Setup mock project query response
-        mock_project.from_access_key.return_value.query.return_value = ("expert answer", None)
+        mock_project.from_access_key.return_value.validate.return_value = ProjectValidateResponse(
+            is_bad_response=True,
+            expert_answer="expert answer",
+            eval_scores={
+                "response_helpfulness": EvalScores(score=0.95, is_bad=False),
+                "trustworthiness": EvalScores(score=0.5, is_bad=True),
+            },
+        )
 
-        validator = Validator(codex_access_key="test")
-        result = validator._remediate(query="test query")  # noqa: SLF001
-
-        # Verify project.query was called
-        mock_project.from_access_key.return_value.query.assert_called_once_with(question="test query", metadata=None)
-        assert result == "expert answer"
+        # Basically any response will be flagged as untrustworthy
+        result = validator.validate(query="test query", context="test context", response="test response")
+        assert result["expert_answer"] == "expert answer"
 
     def test_user_provided_thresholds(self, mock_project: Mock, mock_trustworthy_rag: Mock) -> None:  # noqa: ARG002
         # Test with user-provided thresholds that match evals
@@ -149,15 +127,13 @@ class TestValidator:
         assert_threshold_equal(validator, "trustworthiness", 0.6)
         assert_threshold_equal(validator, "response_helpfulness", 0.23)
 
-        # Test with extra thresholds that should raise ValueError
-        with pytest.raises(ValueError, match="Found thresholds for metrics that are not available"):
-            Validator(codex_access_key="test", bad_response_thresholds={"non_existent_metric": 0.5})
+        # extra threshold should not raise ValueError
+        Validator(codex_access_key="test", bad_response_thresholds={"non_existent_metric": 0.5})
 
     def test_default_thresholds(self, mock_project: Mock, mock_trustworthy_rag: Mock) -> None:  # noqa: ARG002
         # Test with default thresholds (bad_response_thresholds is None)
         validator = Validator(codex_access_key="test")
-        assert_threshold_equal(validator, "trustworthiness", 0.7)
-        assert_threshold_equal(validator, "response_helpfulness", 0.23)
+        assert validator._bad_response_thresholds is None  # noqa: SLF001
 
     def test_edge_cases(self, mock_project: Mock, mock_trustworthy_rag: Mock) -> None:  # noqa: ARG002
         # Note, the `"evals"` field should not be a list of strings in practice, but an Eval from cleanlab_tlm
@@ -165,33 +141,4 @@ class TestValidator:
 
         # Test with empty bad_response_thresholds
         validator = Validator(codex_access_key="test", bad_response_thresholds={})
-        assert_threshold_equal(validator, "trustworthiness", 0.7)  # Default should apply
-
-        validator = Validator(codex_access_key="test", trustworthy_rag_config={"evals": ["non_existent_eval"]})
-        assert_threshold_equal(validator, "non_existent_eval", 0.0)  # Default should apply for undefined thresholds
-
-        # No extra Evals
-        validator = Validator(codex_access_key="test", trustworthy_rag_config={"evals": []})
-        assert_threshold_equal(validator, "trustworthiness", 0.7)  # Default should apply
-        assert_threshold_equal(validator, "response_helpfulness", 0.23)  # Default should apply
-
-        # Test with non-existent evals in trustworthy_rag_config
-        with pytest.raises(ValueError, match="Found thresholds for metrics that are not available"):
-            Validator(codex_access_key="test", bad_response_thresholds={"non_existent_eval": 0.0})
-
-
-def test_validator_with_empty_evals(mock_project: Mock) -> None:  # noqa: ARG001
-    # Mock TrustworthyRAG to simulate empty evals
-    with patch("cleanlab_codex.validator.TrustworthyRAG") as mock_trustworthy_rag:
-        mock_trustworthy_rag.return_value.get_evals.return_value = []
-
-        # Attempt to create a Validator with an invalid threshold
-        with pytest.raises(
-            ValueError,
-            match="Found thresholds for metrics that are not available: {'response_helpfulness'}. Available metrics are determined by the evals parameter provided to TrustworthyRAG plus 'trustworthiness' which is always included.",
-        ):
-            Validator(
-                codex_access_key="test",
-                trustworthy_rag_config={"evals": []},
-                bad_response_thresholds={"response_helpfulness": 0.5},
-            )
+        assert validator._bad_response_thresholds is None  # noqa: SLF001


### PR DESCRIPTION
<!-- TODO: Delete anything from this template that doesn't apply -->

## Key Info

- [Notion ticket](https://www.notion.so/cleanlab/Move-validator-API-logic-to-backend-1d9c7fee85be807aa811ccb604b8d7cd)
- Priority: normal
<!-- priority is low, normal, or urgent; for low or urgent, include your expected deadline -->

## What changed?
Remove redundant validator logic from client library and instead wrap the Codex validator API. The backend now handles the following logic in the `projects.validate` endpoint:
* Run all evals against `TrustworthyRAG`
* Apply eval thresholds, if provided, to determine if the RAG app's generated response is good or bad
  * If the response is determined to be bad, then query Codex project for an expert answer that matches the query

## What do you want the reviewer(s) to focus on?
Elias: Please confirm if the ML team needs/wants any changes to the client library functionality

Angela: General code review (test coverage, naming, format, etc.)

---

### Checklist

- [x] _Did you link the GitHub issue?_
- [ ] _Did you follow deployment steps or bump the version if needed?_
- [x] _Did you add/update tests?_
- [ ] _What QA did you do?_
  - Tested...
