### PR TITLE
Changed Codex mentions to Cleanlab AI Platform on API pages

### DIFF
--- a/src/cleanlab_codex/client.py
+++ b/src/cleanlab_codex/client.py
@@ -1,4 +1,4 @@
-"""Client for interacting with Cleanlab Codex."""
+"""Codex Client for interacting with the Cleanlab AI Platform. Codex is the API interface to the Cleanlab AI Platform."""
 
 from __future__ import annotations
 
@@ -15,9 +15,9 @@ if _TYPE_CHECKING:
 
 class Client:
     """
-    Client for interacting with Cleanlab Codex. In order to use this client, make sure you have an account at [codex.cleanlab.ai](https://codex.cleanlab.ai).
+    Codex Client for interacting with the Cleanlab AI Platform. In order to use this client, make sure you have an account at [codex.cleanlab.ai](https://codex.cleanlab.ai).
 
-    We recommend using the [Web UI](https://codex.cleanlab.ai) to [set up Codex projects](/codex/web_tutorials/create_project), but you can also use this client to programmatically set up Codex projects.
+    We recommend using the [Web UI](https://codex.cleanlab.ai) to [set up Cleanlab projects](/codex/web_tutorials/create_project), but you can also use this client to programmatically set up Cleanlab projects.
     """
 
     def __init__(self, api_key: str | None = None, organization_id: Optional[str] = None):
@@ -56,7 +56,7 @@ class Client:
         return Project(self._client, project_id)
 
     def create_project(self, name: str, description: Optional[str] = None) -> Project:
-        """Create a new Codex project. Project will be created in the organization the client is using.
+        """Create a new Cleanlab project. Project will be created in the organization the client is using.
 
         Args:
             name (str): The name of the project.

--- a/src/cleanlab_codex/project.py
+++ b/src/cleanlab_codex/project.py
@@ -1,4 +1,4 @@
-"""Module for interacting with a Codex project."""
+"""Module for interacting with a Cleanlab project. Codex is the API interface to the Cleanlab AI Platform."""
 
 from __future__ import annotations
 
@@ -36,9 +36,9 @@ class MissingProjectError(Exception):
 
 
 class Project:
-    """Represents a Codex project.
+    """Represents a project in the Cleanlab AI Platform.
 
-    To integrate a Codex project into your RAG/Agentic system, we recommend using the [`Project.validate()` method](/codex/api/python/project#method-validate).
+    To integrate a Cleanlab project into your RAG/Agentic system, we recommend using the [`Project.validate()` method](/codex/api/python/project#method-validate).
     """
 
     def __init__(self, sdk_client: _Codex, project_id: str, *, verify_existence: bool = True):
@@ -90,7 +90,7 @@ class Project:
         name: str,
         description: str | None = None,
     ) -> Project:
-        """Create a new Codex project. This method is not meant to be used directly. Instead, use the [`create_project`](/codex/api/python/client#method-create_project) method on the `Client` class.
+        """Create a new project. This method is not meant to be used directly. Instead, use the [`create_project`](/codex/api/python/client#method-create_project) method on the `Client` class.
 
         Args:
             sdk_client (Codex): The Codex SDK client to use to create the project. This client must be authenticated with a user-level API key.

--- a/src/cleanlab_codex/types/organization.py
+++ b/src/cleanlab_codex/types/organization.py
@@ -1,4 +1,4 @@
-"""Types for Codex organizations."""
+"""Types for Cleanlab organizations. Codex is the API interface to the Cleanlab AI Platform."""
 
 from codex.types.users.myself.user_organizations_schema import (
     Organization as _Organization,
@@ -11,7 +11,7 @@ class Organization(_Organization): ...
 
 
 Organization.__doc__ = f"""
-Type representing an organization in Codex.
+Type representing a Cleanlab organization in the Cleanlab AI Platform.
 
 {generate_class_docstring(_Organization, name=Organization.__name__)}
 """

--- a/src/cleanlab_codex/types/project.py
+++ b/src/cleanlab_codex/types/project.py
@@ -1,4 +1,4 @@
-"""Types for Codex projects."""
+"""Types for Cleanlab projects. Codex is the API interface to the Cleanlab AI Platform."""
 
 from codex.types.project_create_params import Config
 
@@ -9,7 +9,7 @@ class ProjectConfig(Config): ...
 
 
 ProjectConfig.__doc__ = f"""
-    Type representing options that can be configured for a Codex project.
+    Type representing options that can be configured for a Cleanlab project.
 
     {generate_class_docstring(Config, name=ProjectConfig.__name__)}
     ---
@@ -19,7 +19,7 @@ ProjectConfig.__doc__ = f"""
     Distance threshold used to determine if two questions in a project are similar.
     The metric used is cosine distance. Valid threshold values range from 0 (identical vectors) to 1 (orthogonal vectors).
     While cosine distance can extend to 2 (opposite vectors), we limit this value to 1 since finding matches that are less similar than "unrelated" (orthogonal)
-    content would not improve results of the system querying the Codex project.
+    content would not improve results of the system querying the Cleanlab project.
     """
 
 


### PR DESCRIPTION
Updated for each page the mention from "Codex" -> "Cleanlab AI Platform"