### PR TITLE
Feature - add user feedback to query log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.27] 2025-08-22
+
+- Add user feedback support for query logs, `project.add_user_feedback()`
+
 ## [1.0.26] 2025-07-29
 
 - Add tool call support to `project.validate()`
@@ -124,7 +128,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `cleanlab-codex` client library.
 
-[Unreleased]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.26...HEAD
+[Unreleased]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.27...HEAD
+[1.0.27]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.26...v1.0.27
 [1.0.26]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.25...v1.0.26
 [1.0.25]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.24...v1.0.25
 [1.0.24]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.23...v1.0.24

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "cleanlab-tlm~=1.1,>=1.1.14",
-  "codex-sdk==0.1.0a24",
+  "codex-sdk==0.1.0a25",
   "pydantic>=2.0.0, <3",
 ]
 

--- a/src/cleanlab_codex/__about__.py
+++ b/src/cleanlab_codex/__about__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: MIT
-__version__ = "1.0.26"
+__version__ = "1.0.27"

--- a/src/cleanlab_codex/project.py
+++ b/src/cleanlab_codex/project.py
@@ -216,3 +216,17 @@ class Project:
             answer=answer,
             extra_headers=_AnalyticsMetadata().to_headers(),
         )
+
+    def add_user_feedback(self, log_id: str, key: str) -> None:
+        """Add user feedback to a query logged in the project.
+
+        Args:
+            log_id (str): The ID of the query log to add feedback to.
+            key (str): A key describing the criteria of the feedback, eg 'rating'.
+        """
+        self._sdk_client.projects.query_logs.add_user_feedback(
+            project_id=self.id,
+            query_log_id=log_id,
+            key=key,
+            extra_headers=_AnalyticsMetadata().to_headers(),
+        )

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -22,6 +22,7 @@ FAKE_PROJECT_NAME = "Test Project"
 FAKE_PROJECT_DESCRIPTION = "Test Description"
 DEFAULT_PROJECT_CONFIG = Config()
 DUMMY_ACCESS_KEY = "sk-1-EMOh6UrRo7exTEbEi8_azzACAEdtNiib2LLa1IGo6kA"
+FAKE_LOG_ID = str(uuid.uuid4())
 
 
 def test_project_validate_with_dict_response(
@@ -43,6 +44,7 @@ def test_project_validate_with_dict_response(
         },
         escalated_to_sme=True,
         should_guardrail=False,
+        log_id=FAKE_LOG_ID,
     )
     mock_client_from_api_key.projects.validate.return_value = expected_result
     mock_client_from_api_key.projects.create.return_value.id = FAKE_PROJECT_ID
@@ -135,6 +137,7 @@ def test_project_validate_with_tools(
         },
         escalated_to_sme=True,
         should_guardrail=False,
+        log_id=FAKE_LOG_ID,
     )
     mock_client_from_api_key.projects.validate.return_value = expected_result
     mock_client_from_api_key.projects.create.return_value.id = FAKE_PROJECT_ID


### PR DESCRIPTION
Allows clients to add custom user feedback to a specific query log, e.g. `"thumbs_up" | "thumbs_down"`