### PR TITLE
upgrade codex-python version to v0.1.0-alpha.32 to include guardrailed_fallback in /validate's response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.33] 2025-11-05
+
+- Upgrade codex-python version to v0.1.0a32
+
 ## [1.0.32] 2025-10-28
 
 - Add `Client.create_project_from_template()` method to create a new project from a template
@@ -150,7 +154,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `cleanlab-codex` client library.
 
-[Unreleased]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.32...HEAD
+[Unreleased]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.33...HEAD
+[1.0.33]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.32...v1.0.33
 [1.0.32]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.31...v1.0.32
 [1.0.31]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.30...v1.0.31
 [1.0.30]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.29...v1.0.30

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "cleanlab-tlm~=1.1,>=1.1.14",
-  "codex-sdk==0.1.0a31",
+  "codex-sdk==0.1.0a32",
   "pydantic>=2.0.0, <3",
 ]
 

--- a/src/cleanlab_codex/__about__.py
+++ b/src/cleanlab_codex/__about__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: MIT
-__version__ = "1.0.32"
+__version__ = "1.0.33"


### PR DESCRIPTION
upgrade codex-python version to v0.1.0-alpha.32 to include guardrailed_fallback in /validate's response

<!-- TODO: Delete anything from this template that doesn't apply -->

## Key Info

- Implementation plan: [link](https://www.notion.so/cleanlab/Fallback-answers-27dc7fee85be8012be23c6166dbb4fd0?source=copy_link)
- Priority: 
normal

## What changed?
Refer to https://github.com/cleanlab/codex/pull/1544

## What do you want the reviewer(s) to focus on?
-
---

### Checklist

- [ ] _Did you link the GitHub issue?_
- [ ] _Did you follow deployment steps or bump the version if needed?_
- [ ] _Did you add/update tests?_
- [X] _What QA did you do?_
  - Tested /validate response
