### PR TITLE
update to use new expert answer endpoint for adding expert answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.34] 2025-11-18
+
+- Add `Project.add_expert_answer()` method to add an expert answer to a project
+- Deprecate `Project.add_remediation()` method
+- Upgrade codex-python version to v0.1.0a33
+
 ## [1.0.33] 2025-11-05
 
 - Upgrade codex-python version to v0.1.0a32
@@ -154,7 +160,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `cleanlab-codex` client library.
 
-[Unreleased]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.33...HEAD
+[Unreleased]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.34...HEAD
+[1.0.34]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.33...v1.0.34
 [1.0.33]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.32...v1.0.33
 [1.0.32]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.31...v1.0.32
 [1.0.31]: https://github.com/cleanlab/cleanlab-codex/compare/v1.0.30...v1.0.31

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
   "cleanlab-tlm~=1.1,>=1.1.14",
-  "codex-sdk==0.1.0a32",
+  "codex-sdk==0.1.0a33",
   "pydantic>=2.0.0, <3",
 ]
 

--- a/src/cleanlab_codex/__about__.py
+++ b/src/cleanlab_codex/__about__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: MIT
-__version__ = "1.0.33"
+__version__ = "1.0.34"

--- a/src/cleanlab_codex/project.py
+++ b/src/cleanlab_codex/project.py
@@ -238,17 +238,34 @@ class Project:
             eval_scores=eval_scores,
         )
 
+    def add_expert_answer(self, question: str, answer: str) -> None:
+        """Add an expert answer to the project. An expert answer represents a query and answer pair that is expert verified
+        and should be used to answer future queries to the AI system that are similar to the query.
+
+        Args:
+            query (str): The query to add to the project.
+            answer (str): The expert answer for the query.
+        """
+        self._sdk_client.projects.remediations.expert_answers.create(
+            project_id=self.id,
+            query=question,
+            answer=answer,
+            extra_headers=_AnalyticsMetadata().to_headers(),
+        )
+
     def add_remediation(self, question: str, answer: str | None = None) -> None:
-        """Add a remediation to the project. A remediation represents a question and answer pair that is expert verified
+        """DEPRECATED: Use `add_expert_answer` instead.
+
+        Add a remediation to the project. A remediation represents a question and answer pair that is expert verified
         and should be used to answer future queries to the AI system that are similar to the question.
 
         Args:
             question (str): The question to add to the project.
             answer (str, optional): The expert answer for the question. If not provided, the question will be added to the project without an expert answer.
         """
-        self._sdk_client.projects.remediations.create(
+        self._sdk_client.projects.remediations.expert_answers.create(
             project_id=self.id,
-            question=question,
+            query=question,
             answer=answer,
             extra_headers=_AnalyticsMetadata().to_headers(),
         )


### PR DESCRIPTION
## What changed?

- Deprecates `Project.add_remediation()`
- Adds new method `Project.add_expert_answer()` to replace it. This method uses the new expert answer endpoints since there are now three types of remediations.

## What do you want the reviewer(s) to focus on?

---

### Checklist

- [ ] _Did you link the GitHub issue?_
- [ ] _Did you follow deployment steps or bump the version if needed?_
- [ ] _Did you add/update tests?_
- [ ] _What QA did you do?_
  - Tested...
